### PR TITLE
Readme.md - fix first line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-This is a fork of https://sourceforge.net/projects/winmerge(https://bitbucket.org/kimmov/winmerge-v2)
+This is a fork of https://sourceforge.net/projects/winmerge (https://bitbucket.org/kimmov/winmerge-v2)
 
 # Differences from orignal
 


### PR DESCRIPTION
 The first line of readme.md needs a space character between the end of the
	first URL and the following parenthesis '('.  Without the space the two
	separate URLs are parsed by most browsers as one long (and useless)
	URL.

Thank You !!