### PR TITLE
Show "(Debug)" in About dialog

### DIFF
--- a/Src/ConfigLog.cpp
+++ b/Src/ConfigLog.cpp
@@ -327,8 +327,18 @@ String CConfigLog::GetBuildFlags() const
 {
 	String flags;
 
-#ifdef WIN64
+#if defined WIN64
 	flags += _T(" WIN64 ");
+#elif defined WIN32
+	flags += _T(" WIN32 ");
+#endif
+
+#if defined UNICODE
+	flags += _T(" UNICODE ");
+#endif
+
+#if defined _DEBUG
+	flags += _T(" _DEBUG ");
 #endif
 
 	return flags;

--- a/Src/MergeApp.cpp
+++ b/Src/MergeApp.cpp
@@ -157,7 +157,8 @@ AboutInfo::AboutInfo()
 #endif
 
 #if defined _M_IX86
-	version += _T(" x86");
+	version += _T(" ");
+	version += _("x86");
 #elif defined _M_IA64
 	version += _T(" IA64");
 #elif defined _M_X64
@@ -165,10 +166,16 @@ AboutInfo::AboutInfo()
 	version += _("X64");
 #endif
 
+#if defined _DEBUG
+	version += _T(" (");
+	version += _("Debug");
+	version += _T(")");
+#endif
+
 	copyright = _("WinMerge comes with ABSOLUTELY NO WARRANTY. This is free software and you are welcome to redistribute it under certain circumstances; see the GNU General Public License in the Help menu for details.");
 	copyright += _T("\n");
 	copyright += verinfo.GetLegalCopyright();
-	copyright += _T(" All rights reserved.");
+	copyright += _T(" - All rights reserved.");
 
 	private_build = verinfo.GetPrivateBuild();
 	if (!private_build.empty())


### PR DESCRIPTION
Show "(Debug)" in **About** dialog 
* Also allow text of `"x86"` in About dialog to be translated.
* Also show `WIN32`, `UNICODE`, `_DEBUG` in Configuration log
	when appropriate.

**Implementation:**
* Src/ConfigLog.cpp - `GetBuildFlags()` - lines 330-341 - new code to add a few
	more configuration define values to the build information string for the 
	config log.
* Src/MergeApp.cpp - `AboutInfo()` - lines 160-161 - add `"(debug)"` and reformat
	`" x86"` to have `" "` separated so that "x86" can be translated.

