### PR TITLE
Properly handle 3-way comparison of Binary files.

### DIFF
--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -1085,7 +1085,7 @@ bool CDiffWrapper::Diff2Files(struct change ** diffs, DiffFileData *diffData,
 	SE_Handler seh;
 	try
 	{
-		// Diff files. depth is zero because we are not 6comparing dirs
+		// Diff files. depth is zero because we are not comparing dirs
 		*diffs = diff_2_files (diffData->m_inf, 0, bin_status,
 				(m_pMovedLines[0] != NULL), bin_file);
 		CopyDiffutilTextStats(diffData->m_inf, diffData);


### PR DESCRIPTION
## Properly handle 3-way comparison of Binary files.

**Symptom:** Binary files always mis-compares with 3-way comparison,
	although the same files compare correctly with 2-way compares.

**Background:** 3-way comparison of files F0, F1 and F2 is handled by
	two 2-way comparisons of F1/F0 and F1/F2.  However, the two 2-way 
	comparisons for binary are slightly different from the standard 
	2-way text comparison.
	
**Root Problems** (all line numbers are for this PR only): 
 * See procedure` read_files()` in **Src/diffutils/src/io.c** 
	(now at 1021-1078).  This area of code was allowing binary files to
	be treated as text, looking for endline situations and modifying the 
	contents of the first `filevec[i].buffer[]` by placing sentinel 
	markers into that buffer.  But this was only done for one file, F1 
	in the example above.  The contents of  F0 and F2 were not being 
	modified.  This caused the `memcmp()` in `diff_2_files()` in 
	**Src/diffutils/src/analyze.c** (now at 908-914) to detect a 
	mis-compare.
 * See procedure `diff_2_files()` in **Src/diffutils/src/analyze.c**
	(now at 841-1119).  A binary comparison is flagged by `read_files()`
	and the code to perform that comparison is at lines 856-926.  
	Because `read_files()` was only checking one file (e.g. F1), the buffer
	size for the other file (e.g. F0 or F2) was never changed to be 
	identical to the size for F1.  This made it impossible for the 
	comparison loop to stay in sync between the two files.

**Solution:** 
 * Within `read_files()` (**io.c** lines 993-1119), after `appears_binary` flag has 
	been set, there is new logic that allocates buffers for both files, 
	based on the size of existing buffers, the file size, and a maximum 
	threshold.  Then, at line 1077, binary file processing ends and 
	returns to the caller.  [It is within `find_identical_ends()` that 
	buffers are allocated for text files and the search for text-line 
	boundaries occurs, and was incorrectly used for binary files.]
 * Within `diff_2_files()` (**analyze.c** lines 841-1119), lines 856-926 is the code
	that performs the 2-way binary comparison, after `read_files()` has 
	determined that at least one file is binary.  Tests are made at lines
	860-872 to determine if inequality can be known without reading the
	data.  Lines 880-891 make sure that buffers of the same size are 
	read from each file.  Lines 894-905 determine if the buffer contents
	are compatible. Lines 907-914 actually compare the data values of 
	the two buffers.  The outer-loop of lines 877-919 will repeat to 
	read each subsequent block.  [Note: it is typical to enter this 
	loop at line 877 [the `for (;;)` statement] with some data already 
	read into` filevec[0].buffer`, but not a complete buffer's amount; 
	likewise `filevec[1].buffer` will typically still be empty.]

**Incidental changes...**
 * Trivial fix to a comment, discovered while reading code in 
	**Src/DiffWrapper.cpp**, line 1088.
 * Trivial column alignment issue in **analyze.c** at lines 960-964.
 * Better checking for non-existent files with more use of `S_ISREG()`
	define (internally, non-existent files are handled with an open 
	descriptor on the `NUL:` device).  This allow small optimization of 
	buffer allocation.  
 * Assert that files opened as `S_ISCHR()` really are the `NUL:` file 
 