### PR TITLE
Use proper font for View>Use Default Font menu item

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -380,7 +380,7 @@ void CDirView::OnInitialUpdate()
 #endif
 
 	// Load user-selected font
-	if (GetOptionsMgr()->GetBool(String(OPT_FONT_DIRCMP) + OPT_FONT_USECUSTOM))
+	if (GetOptionsMgr()->GetBool(OPT_FONT_DIRCMP + OPT_FONT_USECUSTOM))
 	{
 		m_font.CreateFontIndirect(&GetMainFrame()->m_lfDir);
 		CWnd::SetFont(&m_font, TRUE);

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3886,7 +3886,7 @@ void CMergeEditView::ZoomText(short amount)
 
 	if ( amount == 0)
 	{
-		nPointSize = -MulDiv(GetOptionsMgr()->GetInt(String(OPT_FONT_FILECMP) + OPT_FONT_HEIGHT), 72, nLogPixelsY);
+		nPointSize = -MulDiv(GetOptionsMgr()->GetInt(OPT_FONT_FILECMP + OPT_FONT_HEIGHT), 72, nLogPixelsY);
 	}
 
 	nPointSize += amount;

--- a/Src/OptionsFont.cpp
+++ b/Src/OptionsFont.cpp
@@ -1,54 +1,122 @@
 /** 
  * @file  OptionsFont.cpp
  *
- * @brief Implementation for OptionsFont class.
+ * @brief Implementation for Options::Font class.
  */
 #include "OptionsFont.h"
 #include "unicoder.h"
 #include "ExConverter.h"
 #include "OptionsDef.h"
 #include "OptionsMgr.h"
+#include <cassert>
 
 namespace Options { namespace Font {
 
 /**
- * @brief Set default font values.
+ * @brief Initialize basic default values in a LOGFONT structure. 
+ * A helper function for SetDefaults(); it should not be used otherwise.
+ */
+void InitializeLogFont(LOGFONT &logfont, int lfHeight, int lfCharSet, int lfPitchAndFamily, String lfFaceName)
+{
+	logfont.lfHeight = lfHeight;
+	logfont.lfWidth = 0;
+	logfont.lfEscapement = 0;
+	logfont.lfOrientation = 0;
+	logfont.lfWeight = FW_NORMAL;
+	logfont.lfItalic = false;
+	logfont.lfUnderline = false;
+	logfont.lfStrikeOut = false;
+	logfont.lfCharSet = lfCharSet;
+	logfont.lfOutPrecision = OUT_STRING_PRECIS;
+	logfont.lfClipPrecision = CLIP_STROKE_PRECIS;
+	logfont.lfQuality = DRAFT_QUALITY;
+	logfont.lfPitchAndFamily = lfPitchAndFamily;
+	lstrcpyn(logfont.lfFaceName, lfFaceName.c_str(), (sizeof(logfont.lfFaceName)/sizeof(logfont.lfFaceName[0])) );
+}
+
+/**
+ * @brief Initialize the in-memory Options::Font structure (and possibly the related Registry entries)
+ * for both File-Contents and Directory-Tree windows.
  */
 void SetDefaults(COptionsMgr *pOptionsMgr)
 {
-	CodePageInfo cpi = {0};
-	cpi.bGDICharset = ANSI_CHARSET;
-	cpi.fixedWidthFont = _T("Courier New");
-
-	IExconverter *pexconv = Exconverter::getInstance();
-	if (pexconv)
-		pexconv->getCodePageInfo(GetACP(), &cpi);
-
 	HDC hDC = GetDC(NULL);
+	const int logPixelsY = GetDeviceCaps(hDC, LOGPIXELSY);
+
+	// *****
+	// File-Contents windows use fixed-width fonts.  Here we discover the 
+	// correct default fontname from the system code page, if possible.  The 
+	// default size is 12 points.  If a fontname cannot be found (why?),   
+	// "Courier New" will be used for the fontname.
+	LOGFONT fontFile = {0};
+	const int pointsFile = 12;
+
+	CodePageInfo cpi = {0};
+	IExconverter *pexconv = Exconverter::getInstance();
+	if (pexconv==NULL || !pexconv->getCodePageInfo(GetACP(), &cpi))
+	{
+		assert(false);	// this should never fail (???)
+		cpi.bGDICharset = ANSI_CHARSET;
+		cpi.fixedWidthFont = _T("Courier New");
+	}
+	InitializeLogFont(fontFile, -::MulDiv(pointsFile, logPixelsY, 72), cpi.bGDICharset, FF_MODERN | FIXED_PITCH, cpi.fixedWidthFont);
+
+	
+	// *****
+	// The Directory-Tree window uses (by default) the program's Menu font and size;  if 
+	// that cannot be determined (why?), 9-point "Segoe UI" is used (typical since Win7).
+	LOGFONT fontDir = {0};
+	const int pointsDir = 9;
+	NONCLIENTMETRICS ncm = { 0 };
+	ncm.cbSize = sizeof(NONCLIENTMETRICS);
+	if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0))
+	{
+		const int lfHeight = -::MulDiv(pointsDir, logPixelsY, 72);
+		fontDir = ncm.lfMenuFont;
+		if (abs(fontDir.lfHeight) > abs(lfHeight))
+			fontDir.lfHeight = lfHeight;
+		if (wcscmp(fontDir.lfFaceName, L"Meiryo") == 0 || wcscmp(fontDir.lfFaceName, L"\U000030e1\U000030a4\U000030ea\U000030aa"/* "Meiryo" in Japanese */) == 0)
+			wcscpy_s(fontDir.lfFaceName, L"Meiryo UI");
+	}
+	else
+	{	
+		assert(false);	// this should never fail (???)
+		InitializeLogFont(fontDir, -::MulDiv(pointsDir, logPixelsY, 72), DEFAULT_CHARSET, FF_DONTCARE, L"Segoe UI");
+	}
+	
+	// *****
+	// The values generated above are used as the 'default' Options::Font values.  The 'actual' value 
+	// for each option is obtained from the Registry, if the entry exists.  If the Registry entry
+	// does not exist, it is built using this given 'default' value and the 'actual' value becomes
+	// the same as the 'default'.
 	for (int i = 0; i < 2; ++i)
 	{
+		LOGFONT thisFont = (i == 0 ? fontFile : fontDir);
 		String name = (i == 0 ? OPT_FONT_FILECMP : OPT_FONT_DIRCMP);
+
 		pOptionsMgr->InitOption(name + OPT_FONT_USECUSTOM, false);
-		pOptionsMgr->InitOption(name + OPT_FONT_POINTSIZE, 0);
-		pOptionsMgr->InitOption(name + OPT_FONT_HEIGHT, -MulDiv(12, GetDeviceCaps(hDC, LOGPIXELSY), 72));
-		pOptionsMgr->InitOption(name + OPT_FONT_ESCAPEMENT, 0);
-		pOptionsMgr->InitOption(name + OPT_FONT_ORIENTATION, 0);
-		pOptionsMgr->InitOption(name + OPT_FONT_WEIGHT, FW_NORMAL);
-		pOptionsMgr->InitOption(name + OPT_FONT_ITALIC, false);
-		pOptionsMgr->InitOption(name + OPT_FONT_UNDERLINE, false);
-		pOptionsMgr->InitOption(name + OPT_FONT_STRIKEOUT, false);
-		pOptionsMgr->InitOption(name + OPT_FONT_OUTPRECISION, OUT_STRING_PRECIS);
-		pOptionsMgr->InitOption(name + OPT_FONT_CLIPPRECISION, CLIP_STROKE_PRECIS);
-		pOptionsMgr->InitOption(name + OPT_FONT_QUALITY, DRAFT_QUALITY);
-		pOptionsMgr->InitOption(name + OPT_FONT_PITCHANDFAMILY, FF_MODERN | FIXED_PITCH);
-		pOptionsMgr->InitOption(name + OPT_FONT_CHARSET, (int) cpi.bGDICharset);
-		pOptionsMgr->InitOption(name + OPT_FONT_FACENAME, ucr::toTString(cpi.fixedWidthFont));
+		pOptionsMgr->InitOption(name + OPT_FONT_POINTSIZE, ::MulDiv(abs(thisFont.lfHeight), 72, logPixelsY));
+		pOptionsMgr->InitOption(name + OPT_FONT_HEIGHT, thisFont.lfHeight);
+		pOptionsMgr->InitOption(name + OPT_FONT_ESCAPEMENT, thisFont.lfEscapement);
+		pOptionsMgr->InitOption(name + OPT_FONT_ORIENTATION, thisFont.lfOrientation);
+		pOptionsMgr->InitOption(name + OPT_FONT_WEIGHT, thisFont.lfWeight);
+		pOptionsMgr->InitOption(name + OPT_FONT_ITALIC, thisFont.lfItalic != 0);
+		pOptionsMgr->InitOption(name + OPT_FONT_UNDERLINE, thisFont.lfUnderline != 0);
+		pOptionsMgr->InitOption(name + OPT_FONT_STRIKEOUT, thisFont.lfStrikeOut != 0);
+		pOptionsMgr->InitOption(name + OPT_FONT_CHARSET, thisFont.lfCharSet);
+		pOptionsMgr->InitOption(name + OPT_FONT_OUTPRECISION, thisFont.lfOutPrecision);
+		pOptionsMgr->InitOption(name + OPT_FONT_CLIPPRECISION, thisFont.lfClipPrecision);
+		pOptionsMgr->InitOption(name + OPT_FONT_QUALITY, thisFont.lfQuality);
+		pOptionsMgr->InitOption(name + OPT_FONT_PITCHANDFAMILY, thisFont.lfPitchAndFamily);
+		pOptionsMgr->InitOption(name + OPT_FONT_FACENAME, ucr::toTString(thisFont.lfFaceName));
 	}
 	ReleaseDC(NULL, hDC);
 }
 
 LOGFONT Load(const COptionsMgr *pOptionsMgr, const String& name)
 {
+	// Build a new LOGFONT with values from the 'actual' values of the in-memory Options::Font table.
+	// The Registry is not accessed.
 	LOGFONT lfnew = { 0 };
 	HDC hDC = GetDC(NULL);
 	lfnew.lfHeight = -MulDiv(pOptionsMgr->GetInt(name + OPT_FONT_POINTSIZE), GetDeviceCaps(hDC, LOGPIXELSY), 72);
@@ -74,15 +142,18 @@ LOGFONT Load(const COptionsMgr *pOptionsMgr, const String& name)
 
 void Save(COptionsMgr *pOptionsMgr, const String& name, const LOGFONT* lf, bool bUseCustom)
 {
+	// Store LOGFONT values into both the 'actual' value of the in-memory Options::Font table, and 
+	// into the appropriate Registry entries.
 	HDC hDC = GetDC(NULL);
 	pOptionsMgr->SaveOption(name + OPT_FONT_USECUSTOM, bUseCustom);
 	pOptionsMgr->SaveOption(name + OPT_FONT_POINTSIZE, -MulDiv(lf->lfHeight, 72, GetDeviceCaps(hDC, LOGPIXELSY)));
+	pOptionsMgr->SaveOption(name + OPT_FONT_HEIGHT, lf->lfHeight);
 	pOptionsMgr->SaveOption(name + OPT_FONT_ESCAPEMENT, lf->lfEscapement);
 	pOptionsMgr->SaveOption(name + OPT_FONT_ORIENTATION, lf->lfOrientation);
 	pOptionsMgr->SaveOption(name + OPT_FONT_WEIGHT, lf->lfWeight);
-	pOptionsMgr->SaveOption(name + OPT_FONT_ITALIC, lf->lfItalic);
-	pOptionsMgr->SaveOption(name + OPT_FONT_UNDERLINE, lf->lfUnderline);
-	pOptionsMgr->SaveOption(name + OPT_FONT_STRIKEOUT, lf->lfStrikeOut);
+	pOptionsMgr->SaveOption(name + OPT_FONT_ITALIC, lf->lfItalic != 0);
+	pOptionsMgr->SaveOption(name + OPT_FONT_UNDERLINE, lf->lfUnderline != 0);
+	pOptionsMgr->SaveOption(name + OPT_FONT_STRIKEOUT, lf->lfStrikeOut != 0);
 	pOptionsMgr->SaveOption(name + OPT_FONT_CHARSET, lf->lfCharSet);
 	pOptionsMgr->SaveOption(name + OPT_FONT_OUTPRECISION, lf->lfOutPrecision);
 	pOptionsMgr->SaveOption(name + OPT_FONT_CLIPPRECISION, lf->lfClipPrecision);
@@ -94,6 +165,9 @@ void Save(COptionsMgr *pOptionsMgr, const String& name, const LOGFONT* lf, bool 
 
 void Reset(COptionsMgr *pOptionsMgr, const String& name)
 {
+	// Resets the in-memory Options::Font 'actual' values to be original 'default' values.
+	// The Registry values are not modified, except to turn off the OPT_FONT_USECUSTOM 
+	// Registry entry.
 	pOptionsMgr->SaveOption(name + OPT_FONT_USECUSTOM, false);
 	pOptionsMgr->Reset(name + OPT_FONT_POINTSIZE);
 	pOptionsMgr->Reset(name + OPT_FONT_HEIGHT);
@@ -103,11 +177,11 @@ void Reset(COptionsMgr *pOptionsMgr, const String& name)
 	pOptionsMgr->Reset(name + OPT_FONT_ITALIC);
 	pOptionsMgr->Reset(name + OPT_FONT_UNDERLINE);
 	pOptionsMgr->Reset(name + OPT_FONT_STRIKEOUT);
+	pOptionsMgr->Reset(name + OPT_FONT_CHARSET);
 	pOptionsMgr->Reset(name + OPT_FONT_OUTPRECISION);
 	pOptionsMgr->Reset(name + OPT_FONT_CLIPPRECISION);
 	pOptionsMgr->Reset(name + OPT_FONT_QUALITY);
 	pOptionsMgr->Reset(name + OPT_FONT_PITCHANDFAMILY);
-	pOptionsMgr->Reset(name + OPT_FONT_CHARSET);
 	pOptionsMgr->Reset(name + OPT_FONT_FACENAME);
 }
 

--- a/Src/OptionsFont.h
+++ b/Src/OptionsFont.h
@@ -7,6 +7,8 @@ class COptionsMgr;
 
 namespace Options { namespace Font {
 
+
+//void InitializeLogFont(LOGFONT &logfont, int lfHeight, int lfCharSet, int lfPitchAndFamily, String lfFaceName);
 void SetDefaults(COptionsMgr *pOptionsMgr);
 LOGFONT Load(const COptionsMgr *pOptionsMgr, const String& name);
 void Save(COptionsMgr *pOptionsMgr, const String& name, const LOGFONT* lf, bool bUseCustom);


### PR DESCRIPTION
## Use proper font for `View>Use Default Font` menu item

### Symptom: 
Use of the `View > Use Default Font` menu selection always 
sets the Directory Tree window to the 12-point `Courier New` font,
which is not the default font for that window.
	
### Discussion:  
WinMerge has an `Options::Font` structure that maintains an 
in-memory copy of 'actual' and 'default' values for the font of
each of the Directory Tree and File View windows.  This structure
is populated at program initialization by procedure `SetDefaults()`
in file Src/OptionFont.cpp.  The 'default' values are generated by
this procedure, the 'actual' values are loaded from the Registry.
	
The existing code only queries the system for the default fixed-
size font (via the default MIME codepage) and then uses this font
as the 'default' value for the `Options::Font` structure for both
Directory and File windows.  This value is typically `Courier New`.
	
However, WinMerge actually uses the Menu font as the actual Directory
window font if no other font is marked as 'Specified' in the 
Registry.  The default Menu font (for English, since Windows 7) is 
`Segoe UI`.  But this use of `Segoe UI` has never been reflected in the 
`Options::Font` structure, nor in the Registry.

By having the proper information in the 'default' value in the  
`Options::Font `structure, the `View > Use Default Font` menu 
 selection now works correctly.
	
### Implementation: 
- The procedure `SetDefaults()` is modified to additionally capture 
the system-wide Menu font information via `SystemParametersInfo()` 
to be used for the Directory Tree window, while continuing to use the 
codepage MIME font for the File View window.
	
- A "helper" function is added: `InitializeLogFont()`.  It should only 
be used within Src/OptionFont.cpp.  It is documented by comment in 
the Src/OptionFont.h file.
	
- The information in the Registry for the `Options::Font` structure 
now always reflects the values of the in-memory structure, and  
the values being used by the windows themselves.
	

### Incidental changes:
- Numerous added or modified comments in Src/OptionFont.cpp
- Reordering of all Registry related code to be in the canonical 
order implied by the layout of the `LOGFONT `structure itself.
- Explicitly cast the three boolean values (Italic, Underline, 
Strikeout) to boolean to invoke the properly typed `Options::Font`
procedures (`InitOption()`, `SaveOption()`)
- Remove two unnecessary `String()` function references relating to 
font in files Src/DirView.cpp and Src/MergeEditView.cpp