### PR TITLE
Feature/time stars

### DIFF
--- a/Src/DirViewColItems.cpp
+++ b/Src/DirViewColItems.cpp
@@ -1187,6 +1187,7 @@ DirViewColItems::ColGetTextToDisplay(const CDiffContext *pCtxt, int col,
 	String s = (*fnc)(pCtxt, reinterpret_cast<const char *>(&di) + offset);
 
 	// Add '*' to newer time field
+	if (IsColLmTime(col) || IsColMmTime(col) || IsColRmTime(col) )
 	if (m_nDirs < 3)
 	{
 		if (di.diffFileInfo[0].mtime != 0 || di.diffFileInfo[1].mtime != 0)
@@ -1199,6 +1200,16 @@ DirViewColItems::ColGetTextToDisplay(const CDiffContext *pCtxt, int col,
 			{
 				s.insert(0, _T("* "));
 			}
+			else
+			{
+				s.insert(0, _T("  "));  // Looks best with a fixed-font, but not too bad otherwise
+			}
+			// GreyMerlin (14 Nov 2009) - the flagging of Date needs to be done with
+			//		something not involving extra characters.  Perhaps <red> for oldest, 
+			//		<green> for newest.  Note (20 March 2017): the introduction of 3-Way
+			//		Merge and the yellow difference highlighting adds to the design
+			//		difficulty of any changes.  So maybe this "* "/"  " scheme is good enough.
+
 		}
 	}
 	else
@@ -1214,6 +1225,12 @@ DirViewColItems::ColGetTextToDisplay(const CDiffContext *pCtxt, int col,
 			{
 				s.insert(0, _T("* "));
 			}
+			else
+			{
+				s.insert(0, _T("  "));  // Looks best with a fixed-font, but not too bad otherwise
+			}
+			// GreyMerlin (14 Nov 2009) - See note above.
+
 		}
 	}
 


### PR DESCRIPTION
## Cleanup Date column alignment

### Symptom: 
Date columns use a leading `"* "` to indicate which date
is newest.  This makes the column look ragged and awkward.

### Implementation: 
Add an appropriate `"  "` as leading text for date
columns that do not have the `"* "` appended.

### Comment: 
Clearly the two characters `"* "` occupy slightly more
horizontal space than two `"  "` characters, unless a fixed-
font is used.  Nonetheless, the Date portions of the columns 
almost appear aligned with the default Segoe UI font.  

The star is clearly more visible, which is the whole point of it
being added.

### Historical Comment: 
I've been using an equivalent to this patch
in WinMergeU since 11/2009.  I've never been visually
aware of the slight column mis-alignment caused by
proportional-width fonts.

### A visual of Before ...

![sample-before](https://cloud.githubusercontent.com/assets/11866074/24124693/36418b02-0d82-11e7-9450-e21ca57b5e81.jpg)

### A visual of After (i.e. with this modification) ...

![sample-after](https://cloud.githubusercontent.com/assets/11866074/24124706/41f478a6-0d82-11e7-9c9f-ee2b6c3e735f.jpg)

