### PR TITLE
Fix Memory Leak with Drop Targets

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -1363,6 +1363,7 @@ DoDragScroll (const CPoint & point)
 void CCrystalEditView::
 SetAlternateDropTarget (IDropTarget *pDropTarget)
 {
+  ASSERT(m_pDropTarget->m_pAlternateDropTarget == NULL);
   m_pDropTarget->m_pAlternateDropTarget = pDropTarget;
 }
 
@@ -1443,6 +1444,7 @@ OnDestroy ()
   if (m_pDropTarget != NULL)
     {
       m_pDropTarget->Revoke ();
+	  delete m_pDropTarget->m_pAlternateDropTarget;
       delete m_pDropTarget;
       m_pDropTarget = NULL;
     }


### PR DESCRIPTION
## Fix Memory Leak with Drop Targets

### Symptom:
* There will be 4 memory leaks (each 80 bytes long) reported at
	program termination for each File-View window that is opened.

### Discussion:
 * This is only noticeable with a `_DEBUG` compilation.
 * This will happen when either Text or Binary files are being
	viewed/edited.
 * Each File-View window establishes four Drop Targets and registers
 	them with Windows.  Each also establishes an 'alternate' Drop
	Target for use with various internal Drag-And-Drop operations.
 * When the edit windows are closed, the Drop Targets are properly
	`Revoke()`'ed and deleted.
 * However: the 'alternate' Drop Targets are not deleted ... MemLeak!

### Implementation:
* procedure `OnDestroy()` in file
	Externals/crystaledit/editlib/ccrystaleditview.cpp now deletes
	the 'alternate' Drop Target before deleting the master one.
* Additionally, there is now an `ASSERT()` in procedure
	`SetAlternateDropTarget()` guarding the assignment of the
	'alternate' to make sure that it was still NULL
