### PR TITLE
Update Boost's checking for new VS2017 Update 3

### DIFF
--- a/Externals/boost/boost/config/compiler/visualc.hpp
+++ b/Externals/boost/boost/config/compiler/visualc.hpp
@@ -316,8 +316,8 @@
 #endif
 
 //
-// last known and checked version is 19.10.25017 (VC++ 2017):
-#if (_MSC_VER > 1910)
+// last known and checked version is 19.11.25506 (VC++ 2017: ver 15.3.0):
+#if (_MSC_VER > 1911)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/Externals/boost/boost/config/compiler/visualc.hpp
+++ b/Externals/boost/boost/config/compiler/visualc.hpp
@@ -316,7 +316,7 @@
 #endif
 
 //
-// last known and checked version is 19.11.25506 (VC++ 2017: ver 15.3.0):
+// last known (but un-checked by Boost.org) version is 19.11.25506 (VS 2017 Update 3) - BillGord 15 Aug 2017
 #if (_MSC_VER > 1911)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"


### PR DESCRIPTION
# Update Boost's checking for new VS2017 Update 3

* VS2017 Update 3 (dated 8/14/2017) changes` _MSC_VER` to `1911`.  See
[https://blogs.msdn.microsoft.com/chuckw/2017/08/14/visual-studio-2017-15-3-update/](https://blogs.msdn.microsoft.com/chuckw/2017/08/14/visual-studio-2017-15-3-update/)

* This cause lots of compilation messages (neither Errors nor Warnings) with the text ``"Unknown compiler version - please run the configure tests and report the results"``.  

 * I have *not* reported this new issue to Boost.org

* This tiny patch will prevent those messages until a newer version of Boost (1.65.0 - now in beta) becomes available.