### PR TITLE
Missing line in .filters file

### DIFF
--- a/Src/Merge.vs2017.vcxproj.filters
+++ b/Src/Merge.vs2017.vcxproj.filters
@@ -1394,6 +1394,7 @@
     </ClInclude>
     <ClInclude Include="MergeStatusBar.h">
       <Filter>MFCGui\Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="PropMarkerColors.h">
       <Filter>MFCGui\Dialogs\PropertyPages</Filter>
     </ClInclude>


### PR DESCRIPTION
 There should be an additional `</ClInclude>` in the file `Merge.vs2017.vcxproj.filters` at line (1397) to properly terminate the entry for `MergeStatusBar.h`, prior to the introduction of `PropMarkerColors.h`

Without this </ClInclude> line, the Solution Explorer for the Merge project is missing all of the file organization.

See also **issue #35**, which is related but different.