### PR TITLE
Tweak vs2017.vcxproj.filters

### DIFF
--- a/Src/Merge.vs2017.vcxproj.filters
+++ b/Src/Merge.vs2017.vcxproj.filters
@@ -754,6 +754,15 @@
     <ClCompile Include="..\Externals\crystaledit\editlib\rust.cpp">
       <Filter>EditLib\parsers</Filter>
     </ClCompile>
+    <ClCompile Include="Test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TestMain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.cpp">
+      <Filter>EditLib</Filter>
+    </ClCompile>
     <ClCompile Include="PropMarkerColors.cpp">
       <Filter>MFCGui\Dialogs\PropertyPages</Filter>
     </ClCompile>
@@ -1394,6 +1403,12 @@
     </ClInclude>
     <ClInclude Include="MergeStatusBar.h">
       <Filter>MFCGui\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TestMain.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.h">
+      <Filter>EditLib</Filter>
     </ClInclude>
     <ClInclude Include="PropMarkerColors.h">
       <Filter>MFCGui\Dialogs\PropertyPages</Filter>


### PR DESCRIPTION
# Tweak vs2017.vcxproj.filters
Various Filters (i.e. compilation instructions and Solution Explorer organization) were not completely copied from vs2015 into vs2017 for various recent changes.