### PR TITLE
Some `size_t` should be `ptrdiff_t`, 

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -2798,8 +2798,6 @@ OnUpdateToolsCharCoding (CCmdUI * pCmdUI)
   pCmdUI->Enable (IsSelection ());
 }
 
-size_t str_pos (LPCTSTR whole, LPCTSTR piece);
-
 void CCrystalEditView::
 OnToolsCharCoding ()
 {

--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -156,7 +156,7 @@ IMPLEMENT_DYNCREATE (CCrystalTextView, CView)
 
 HINSTANCE CCrystalTextView::s_hResourceInst = NULL;
 
-static size_t FindStringHelper(LPCTSTR pszFindWhere, LPCTSTR pszFindWhat, DWORD dwFlags, int &nLen, RxNode *&rxnode, RxMatchRes *rxmatch);
+static ptrdiff_t FindStringHelper(LPCTSTR pszFindWhere, LPCTSTR pszFindWhat, DWORD dwFlags, int &nLen, RxNode *&rxnode, RxMatchRes *rxmatch);
 
 BEGIN_MESSAGE_MAP (CCrystalTextView, CView)
 //{{AFX_MSG_MAP(CCrystalTextView)
@@ -4805,12 +4805,12 @@ PrepareDragData ()
   return hData;
 }
 
-static size_t
+static ptrdiff_t
 FindStringHelper (LPCTSTR pszFindWhere, LPCTSTR pszFindWhat, DWORD dwFlags, int &nLen, RxNode *&rxnode, RxMatchRes *rxmatch)
 {
   if (dwFlags & FIND_REGEXP)
     {
-      size_t pos;
+      ptrdiff_t pos;
 
       if (rxnode)
         RxFree (rxnode);
@@ -5044,7 +5044,7 @@ FindTextInBlock (LPCTSTR pszText, const CPoint & ptStartPosition,
                   line.ReleaseBuffer (ptCurrentPos.x + 1);
                 }
 
-              size_t nFoundPos = -1;
+              ptrdiff_t nFoundPos = -1;
               int nMatchLen = what.GetLength();
               int nLineLen = line.GetLength();
               size_t nPos;

--- a/Externals/crystaledit/editlib/cregexp.h
+++ b/Externals/crystaledit/editlib/cregexp.h
@@ -95,8 +95,8 @@ typedef struct _RxNode RxNode;
 struct _RxNode;
 
 typedef struct {
-    size_t Open[NSEXPS];    // -1 = not matched
-    size_t Close[NSEXPS];
+    ptrdiff_t Open[NSEXPS];    // -1 = not matched
+    ptrdiff_t Close[NSEXPS];
 } RxMatchRes;
 
 RxNode EDITPADC_CLASS *RxCompile(LPCTSTR Regexp, unsigned int RxOpt = RX_CASE);

--- a/Externals/crystaledit/editlib/cs2cs.cpp
+++ b/Externals/crystaledit/editlib/cs2cs.cpp
@@ -61,7 +61,7 @@ str_fill (LPTSTR s, TCHAR ch, long count)
   *s = _T ('\0');
 }
 
-size_t
+ptrdiff_t
 str_pos (LPCTSTR whole, LPCTSTR piece)
 {
   LPCTSTR s = whole;
@@ -107,7 +107,7 @@ skip_word (LPCTSTR s)
   return skip_spaces (s);
 }
 
-size_t
+ptrdiff_t
 get_coding (LPCTSTR name, type_codes *codes, int *coding)
 {
   size_t pos;
@@ -122,11 +122,12 @@ get_coding (LPCTSTR name, type_codes *codes, int *coding)
   return -2;
 }
 
-size_t
+
+ptrdiff_t
 fget_coding (LPCTSTR text, int *coding)
 {
-  size_t posit = 0;
-  size_t i = 0;
+  ptrdiff_t posit = 0;
+  ptrdiff_t i = 0;
   LPCTSTR s, s1;
 
   while ((i = str_pos (text, FD_ENCODING_LBRACKET)) >= 0)
@@ -179,7 +180,7 @@ TCHAR iconvert_char (TCHAR ch, int source_coding, int destination_coding, bool a
 int
 iconvert (LPTSTR string, int source_coding, int destination_coding, bool alphabet_only)
   {
-    size_t posit = -2;
+    ptrdiff_t posit = -2;
     LPCTSTR source_chars, destination_chars, cod_pos = NULL;
     TCHAR ch;
     LPTSTR s = string;

--- a/Src/DiffList.cpp
+++ b/Src/DiffList.cpp
@@ -448,8 +448,8 @@ void DiffList::ConstructSignificantChain()
 	m_lastSignificantLeftRight = -1;
 	m_lastSignificantMiddleRight = -1;
 	m_lastSignificantConflict = -1;
-	int prev = -1;
-	const int size = (int) m_diffs.size();
+	ptrdiff_t prev = -1;
+	const ptrdiff_t size = (int) m_diffs.size();
 
 	// must be called after diff list is entirely populated
     for (int i = 0; i < size; ++i)

--- a/Src/DiffList.h
+++ b/Src/DiffList.h
@@ -105,8 +105,8 @@ public:
  */
 struct DiffRangeInfo: public DIFFRANGE
 {
-	size_t next; /**< link (array index) for doubly-linked chain of non-trivial DIFFRANGEs */
-	size_t prev; /**< link (array index) for doubly-linked chain of non-trivial DIFFRANGEs */
+	ptrdiff_t next; /**< link (array index) for doubly-linked chain of non-trivial DIFFRANGEs */
+	ptrdiff_t prev; /**< link (array index) for doubly-linked chain of non-trivial DIFFRANGEs */
 
 	DiffRangeInfo() { InitLinks(); }
 	explicit DiffRangeInfo(const DIFFRANGE & di) : DIFFRANGE(di) { InitLinks(); }

--- a/Src/codepage_detect.cpp
+++ b/Src/codepage_detect.cpp
@@ -230,7 +230,7 @@ static unsigned GuessEncoding_from_bytes(const String& ext, const char *src, siz
  * @param [in] bGuessEncoding Try to guess codepage (not just unicode encoding).
  * @return Structure getting the encoding info.
  */
-FileTextEncoding GuessCodepageEncoding(const String& filepath, int guessEncodingType, int mapmaxlen)
+FileTextEncoding GuessCodepageEncoding(const String& filepath, int guessEncodingType, ptrdiff_t mapmaxlen)
 {
 	FileTextEncoding encoding;
 	CMarkdown::FileImage fi(filepath.c_str(), mapmaxlen);

--- a/Src/codepage_detect.h
+++ b/Src/codepage_detect.h
@@ -11,4 +11,4 @@
 /** @brief Buffer size used in this file. */
 static const int BufSize = 65536;
 
-FileTextEncoding GuessCodepageEncoding(const String& filepath, int guessEncodingType, int mapmaxlen = BufSize);
+FileTextEncoding GuessCodepageEncoding(const String& filepath, int guessEncodingType, ptrdiff_t mapmaxlen = BufSize);

--- a/Src/stringdiffs.cpp
+++ b/Src/stringdiffs.cpp
@@ -365,6 +365,10 @@ stringdiffs::BuildWordsArray(const String & str, std::vector<word>& words)
 {
 	int i=0, begin=0;
 
+	size_t sLen = str.length();
+	assert(sLen < INT_MAX);
+	int iLen = static_cast<int>(sLen);
+
 	// dummy;
 	words.push_back(word(0, -1, 0, 0));
 
@@ -383,7 +387,7 @@ inspace:
 
 		words.push_back(word(begin, e, dlspace, Hash(str, begin, e, 0)));
 	}
-	if (i == str.length())
+	if (i == iLen)
 		return;
 	begin = i;
 	goto inword;
@@ -391,7 +395,7 @@ inspace:
 	// state when we are inside a word
 inword:
 	bool atspace=false;
-	if (i == str.length() || ((atspace = isSafeWhitespace(str[i])) != 0) || isWordBreak(m_breakType, str.c_str(), i))
+	if (i == iLen || ((atspace = isSafeWhitespace(str[i])) != 0) || isWordBreak(m_breakType, str.c_str(), i))
 	{
 		if (begin<i)
 		{
@@ -401,7 +405,7 @@ inword:
 			
 			words.push_back(word(begin, e, dlword, Hash(str, begin, e, 0)));
 		}
-		if (i == str.length())
+		if (i == iLen)
 		{
 			return;
 		}

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj
@@ -184,6 +184,54 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Externals\gtest\src\gtest-all.cc" />
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-death-test.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-filepath.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-port.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-printers.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-test-part.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-typed-test.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest_main.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\..\Src\Common\ShellFileOperations.cpp" />
     <ClCompile Include="..\..\..\Src\CompareEngines\BinaryCompare.cpp" />
     <ClCompile Include="..\..\..\Src\CompareEngines\ByteComparator.cpp" />
@@ -265,6 +313,32 @@
     <ClCompile Include="..\OptionsMgr\VariantValue_test.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-death-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-message.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-param-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-printers.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-spi.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-test-part.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-typed-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_pred_impl.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_prod.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-death-test-internal.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-filepath.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-internal.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-linked_ptr.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util-generated.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-port.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-string.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-tuple.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-type-util.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\src\gtest-internal-inl.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\..\Src\Common\ShellFileOperations.h" />
     <ClInclude Include="..\..\..\Src\CompareEngines\BinaryCompare.h" />
     <ClInclude Include="..\..\..\Src\CompareEngines\ByteComparator.h" />

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj.filters
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj.filters
@@ -19,6 +19,12 @@
     <Filter Include="gtest">
       <UniqueIdentifier>{20eb57d2-cf08-44a2-b9e0-c7f267013211}</UniqueIdentifier>
     </Filter>
+    <Filter Include="gtest\include">
+      <UniqueIdentifier>{1a47bdcd-4e19-4980-8ce0-6bca0a1f05c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="gtest\include\internal">
+      <UniqueIdentifier>{a16e05ae-b552-4e79-920b-099f70b8e4e9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Src\CompareEngines\ByteComparator.cpp">
@@ -246,6 +252,30 @@
     <ClCompile Include="..\diffutils\mystat_test.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest_main.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-death-test.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-filepath.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-port.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-printers.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-test-part.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-typed-test.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Src\CompareEngines\ByteComparator.h">
@@ -367,6 +397,69 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Src\CompareEngines\TimeSizeCompare.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-string.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-internal.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-death-test-internal.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-filepath.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-linked_ptr.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util-generated.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-tuple.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-type-util.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_pred_impl.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_prod.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-death-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-message.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-param-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-printers.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-spi.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-test-part.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-typed-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\src\gtest-internal-inl.h">
+      <Filter>gtest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
@@ -184,6 +184,54 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Externals\gtest\src\gtest-all.cc" />
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-death-test.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-filepath.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-port.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-printers.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-test-part.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-typed-test.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest_main.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\..\Src\Common\ShellFileOperations.cpp" />
     <ClCompile Include="..\..\..\Src\CompareEngines\BinaryCompare.cpp" />
     <ClCompile Include="..\..\..\Src\CompareEngines\ByteComparator.cpp" />
@@ -265,6 +313,32 @@
     <ClCompile Include="..\OptionsMgr\VariantValue_test.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-death-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-message.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-param-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-printers.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-spi.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-test-part.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-typed-test.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_pred_impl.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_prod.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-death-test-internal.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-filepath.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-internal.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-linked_ptr.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util-generated.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-port.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-string.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-tuple.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-type-util.h" />
+    <ClInclude Include="..\..\..\Externals\gtest\src\gtest-internal-inl.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\..\Src\Common\ShellFileOperations.h" />
     <ClInclude Include="..\..\..\Src\CompareEngines\BinaryCompare.h" />
     <ClInclude Include="..\..\..\Src\CompareEngines\ByteComparator.h" />

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj.filters
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj.filters
@@ -19,6 +19,12 @@
     <Filter Include="gtest">
       <UniqueIdentifier>{20eb57d2-cf08-44a2-b9e0-c7f267013211}</UniqueIdentifier>
     </Filter>
+    <Filter Include="gtest\include">
+      <UniqueIdentifier>{1a47bdcd-4e19-4980-8ce0-6bca0a1f05c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="gtest\include\internal">
+      <UniqueIdentifier>{a16e05ae-b552-4e79-920b-099f70b8e4e9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Src\CompareEngines\ByteComparator.cpp">
@@ -246,6 +252,30 @@
     <ClCompile Include="..\diffutils\mystat_test.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest_main.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-death-test.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-filepath.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-port.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-printers.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-test-part.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Externals\gtest\src\gtest-typed-test.cc">
+      <Filter>gtest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Src\CompareEngines\ByteComparator.h">
@@ -367,6 +397,69 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Src\CompareEngines\TimeSizeCompare.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-string.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-internal.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-death-test-internal.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-filepath.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-linked_ptr.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-param-util-generated.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-tuple.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\internal\gtest-type-util.h">
+      <Filter>gtest\include\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_pred_impl.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest_prod.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-death-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-message.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-param-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-printers.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-spi.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-test-part.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\include\gtest\gtest-typed-test.h">
+      <Filter>gtest\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Externals\gtest\src\gtest-internal-inl.h">
+      <Filter>gtest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Two independent commits ...

### Cleanup: Fixup 1: some `size_t` should be `ptrdiff_t`

 * Some of my recent type changes to `size_t` should have been to `ptrdiff_t` (which is signed).
 * In particular, `str_pos()`, `get_coding()` and `fget_coding()` in  **cs2cs.cpp** use the value `-2` as a return flag.  This was being improperly handled via `size_t`.
 * Finding this change led to other areas (in my recent changes) with similar problems, in particular * `next` and `prev` in the `DirrRangeInfo{}` structure, and `Open[]` and `Close[]` in the `RxMatchRes{}` structure.
 * These changes compile and run correctly with both **VS2015** and **VS2017**.

### Cleanup2: `gtest/*` files into Solution Explorer

 * Recent study of the **UnitTests** project led me to want the base **GoogleTest** files to be more visible 
 * Add the `./External/gtest/*.h` and `*.cc files` into the UnitTests Solution Explorer, with appropriate sub-folders
 * The various `*.cc` files (except for `gtest-all.cc`) are marked with the **'ExcludedFromBuild' = True**  because they are #included and not compiled directly.
 * Changes are for both **VS2015** and **VS2017**.

