### PR TITLE
Level 4 Warning Cleanup, first attempt

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -745,8 +745,8 @@ OnChar (UINT nChar, UINT nRepCnt, UINT nFlags)
               ptCursorPos = ptSelStart;
               if (IsSelection ())
                 {
-                  CPoint ptSelStart, ptSelEnd;
-                  GetSelection (ptSelStart, ptSelEnd);
+                  CPoint ptSelStart1, ptSelEnd1;
+                  GetSelection (ptSelStart1, ptSelEnd1);
             
                   /*SetAnchor (ptCursorPos);
                   SetSelection (ptCursorPos, ptCursorPos);
@@ -754,7 +754,7 @@ OnChar (UINT nChar, UINT nRepCnt, UINT nFlags)
                   EnsureVisible (ptCursorPos);*/
             
                   // [JRT]:
-                  m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_TYPING);
+                  m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_TYPING);
                 }
             }
           else
@@ -956,39 +956,39 @@ OnEditTab ()
   // Overwrite mode, replace next char with tab/spaces
   if (m_bOvrMode)
     {
-      CPoint ptCursorPos = GetCursorPos ();
-      ASSERT_VALIDTEXTPOS (ptCursorPos);
+      CPoint ptCursorPos1 = GetCursorPos ();
+      ASSERT_VALIDTEXTPOS (ptCursorPos1);
 
-      int nLineLength = GetLineLength (ptCursorPos.y);
-      LPCTSTR pszLineChars = GetLineChars (ptCursorPos.y);
+      int nLineLength = GetLineLength (ptCursorPos1.y);
+      LPCTSTR pszLineChars = GetLineChars (ptCursorPos1.y);
 		
       // Not end of line
-      if (ptCursorPos.x < nLineLength)
+      if (ptCursorPos1.x < nLineLength)
         {
           int nTabSize = GetTabSize ();
           int nChars = nTabSize - CalculateActualOffset(
-              ptCursorPos.y, ptCursorPos.x ) % nTabSize;
+              ptCursorPos1.y, ptCursorPos1.x ) % nTabSize;
           ASSERT (nChars > 0 && nChars <= nTabSize);
 
           while (nChars > 0)
             {
-              if (ptCursorPos.x == nLineLength)
+              if (ptCursorPos1.x == nLineLength)
                 break;
-              if (pszLineChars[ptCursorPos.x] == _T ('\t'))
+              if (pszLineChars[ptCursorPos1.x] == _T ('\t'))
                 {
-                  ptCursorPos.x++;
+                  ptCursorPos1.x++;
                   break;
                 }
-              ptCursorPos.x++;
+              ptCursorPos1.x++;
               nChars--;
             }
-          ASSERT (ptCursorPos.x <= nLineLength);
-          ASSERT_VALIDTEXTPOS (ptCursorPos);
+          ASSERT (ptCursorPos1.x <= nLineLength);
+          ASSERT_VALIDTEXTPOS (ptCursorPos1);
 
-          SetSelection (ptCursorPos, ptCursorPos);
-          SetAnchor (ptCursorPos);
-          SetCursorPos (ptCursorPos);
-          EnsureVisible (ptCursorPos);
+          SetSelection (ptCursorPos1, ptCursorPos1);
+          SetAnchor (ptCursorPos1);
+          SetCursorPos (ptCursorPos1);
+          EnsureVisible (ptCursorPos1);
           return;
         }
     }
@@ -1000,8 +1000,8 @@ OnEditTab ()
   // Text selected, no overwrite mode, replace sel with tab
   if (IsSelection ())
     {
-      CPoint ptSelStart, ptSelEnd;
-      GetSelection (ptSelStart, ptSelEnd);
+      CPoint ptSelStart1, ptSelEnd1;
+      GetSelection (ptSelStart1, ptSelEnd1);
 
       /*SetAnchor (ptCursorPos);
       SetSelection (ptCursorPos, ptCursorPos);
@@ -1009,8 +1009,8 @@ OnEditTab ()
       EnsureVisible (ptCursorPos);*/
 
       // [JRT]:
-      m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_TYPING);
-      m_pTextBuffer->InsertText( this, ptSelStart.y, ptSelStart.x, pszText, (int) _tcslen(pszText), y, x, CE_ACTION_TYPING );
+      m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_TYPING);
+      m_pTextBuffer->InsertText( this, ptSelStart1.y, ptSelStart1.x, pszText, (int) _tcslen(pszText), y, x, CE_ACTION_TYPING );
     }
   // No selection, add tab
   else

--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -1036,9 +1036,9 @@ OnEditUntab ()
     return;
 
   bool bTabify = false;
-  CPoint ptSelStart, ptSelEnd;
   if (IsSelection ())
     {
+	  CPoint ptSelStart, ptSelEnd;
       GetSelection (ptSelStart, ptSelEnd);
       bTabify = ptSelStart.y != ptSelEnd.y;
     }
@@ -2366,17 +2366,17 @@ OnEditLowerCase ()
 
       if (IsSelection ())
         {
-          CPoint ptSelStart, ptSelEnd;
-          GetSelection (ptSelStart, ptSelEnd);
+          CPoint ptSelStart1, ptSelEnd1;
+          GetSelection (ptSelStart1, ptSelEnd1);
     
-          ptCursorPos = ptSelStart;
+          ptCursorPos = ptSelStart1;
           /*SetAnchor (ptCursorPos);
           SetSelection (ptCursorPos, ptCursorPos);
           SetCursorPos (ptCursorPos);
           EnsureVisible (ptCursorPos);*/
     
           // [JRT]:
-          m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_LOWERCASE);
+          m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_LOWERCASE);
         }
 
       int x, y;
@@ -2414,17 +2414,17 @@ OnEditUpperCase ()
 
       if (IsSelection ())
         {
-          CPoint ptSelStart, ptSelEnd;
-          GetSelection (ptSelStart, ptSelEnd);
+          CPoint ptSelStart1, ptSelEnd1;
+          GetSelection (ptSelStart1, ptSelEnd1);
     
-          ptCursorPos = ptSelStart;
+          ptCursorPos = ptSelStart1;
           /*SetAnchor (ptCursorPos);
           SetSelection (ptCursorPos, ptCursorPos);
           SetCursorPos (ptCursorPos);
           EnsureVisible (ptCursorPos);*/
     
           // [JRT]:
-          m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_UPPERCASE);
+          m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_UPPERCASE);
         }
 
       int x, y;
@@ -2466,17 +2466,17 @@ OnEditSwapCase ()
 
       if (IsSelection ())
         {
-          CPoint ptSelStart, ptSelEnd;
-          GetSelection (ptSelStart, ptSelEnd);
+          CPoint ptSelStart1, ptSelEnd1;
+          GetSelection (ptSelStart1, ptSelEnd1);
     
-          ptCursorPos = ptSelStart;
+          ptCursorPos = ptSelStart1;
           /*SetAnchor (ptCursorPos);
           SetSelection (ptCursorPos, ptCursorPos);
           SetCursorPos (ptCursorPos);
           EnsureVisible (ptCursorPos);*/
     
           // [JRT]:
-          m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_SWAPCASE);
+          m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_SWAPCASE);
         }
 
       int x, y;
@@ -2531,17 +2531,17 @@ OnEditCapitalize ()
 
       if (IsSelection ())
         {
-          CPoint ptSelStart, ptSelEnd;
-          GetSelection (ptSelStart, ptSelEnd);
+          CPoint ptSelStart1, ptSelEnd1;
+          GetSelection (ptSelStart1, ptSelEnd1);
     
-          ptCursorPos = ptSelStart;
+          ptCursorPos = ptSelStart1;
           /*SetAnchor (ptCursorPos);
           SetSelection (ptCursorPos, ptCursorPos);
           SetCursorPos (ptCursorPos);
           EnsureVisible (ptCursorPos);*/
     
           // [JRT]:
-          m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_CAPITALIZE);
+          m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_CAPITALIZE);
         }
 
       int x, y;
@@ -2600,17 +2600,17 @@ OnEditSentence ()
 
       if (IsSelection ())
         {
-          CPoint ptSelStart, ptSelEnd;
-          GetSelection (ptSelStart, ptSelEnd);
+          CPoint ptSelStart1, ptSelEnd1;
+          GetSelection (ptSelStart1, ptSelEnd1);
     
-          ptCursorPos = ptSelStart;
+          ptCursorPos = ptSelStart1;
           /*SetAnchor (ptCursorPos);
           SetSelection (ptCursorPos, ptCursorPos);
           SetCursorPos (ptCursorPos);
           EnsureVisible (ptCursorPos);*/
     
           // [JRT]:
-          m_pTextBuffer->DeleteText (this, ptSelStart.y, ptSelStart.x, ptSelEnd.y, ptSelEnd.x, CE_ACTION_SENTENCIZE);
+          m_pTextBuffer->DeleteText (this, ptSelStart1.y, ptSelStart1.x, ptSelEnd1.y, ptSelEnd1.x, CE_ACTION_SENTENCIZE);
         }
 
       int x, y;

--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -423,7 +423,7 @@ InsertColumnText (int nLine, int nPos, LPCTSTR pszText, int cchText, int nAction
   int nLineBegin = 0;
   for (int nTextPos = 0; nTextPos < cchText; )
     {
-      TCHAR ch;
+      TCHAR ch = 0;
       aLines.Add ((LPTSTR)&pszText[nTextPos]);
 
       for (; nTextPos < cchText; nTextPos++)

--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -1454,7 +1454,7 @@ void CCrystalTextView::DrawScreenLine( CDC *pdc, CPoint &ptOrigin, const CRect &
   CRect		frect = rcClip;
   const int nLineLength = GetViewableLineLength( ptTextPos.y );
   const int nLineHeight = GetLineHeight();
-  int nBgColorIndexZeorWidthBlock;
+  int nBgColorIndexZeorWidthBlock = COLORINDEX_NONE;
   bool bPrevZeroWidthBlock = false;
   static const int ZEROWIDTHBLOCK_WIDTH = 2;
   size_t nActualItem = 0;

--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -973,10 +973,10 @@ ExpandChars (LPCTSTR pszChars, int nOffset, int nCount, CString & line, int nAct
     }
   else
     {
-      for (int i=0; i<nLength; ++i)
+      for (int i1=0; i1<nLength; ++i1)
       {
-        line += pszChars[i];
-        nCurPos += GetCharWidthFromChar(pszChars[i]) / GetCharWidth();
+        line += pszChars[i1];
+        nCurPos += GetCharWidthFromChar(pszChars[i1]) / GetCharWidth();
       }
     }
   return nCurPos;
@@ -1098,22 +1098,22 @@ DrawLineHelperImpl (CDC * pdc, CPoint & ptOrigin, const CRect & rcClip,
               // A raw estimate of the number of characters to display
               // For wide characters, nCountFit may be overvalued
               int nWidth = rcClip.right - ptOrigin.x;
-              int nCount = lineLen - ibegin;
+              int nCount1 = lineLen - ibegin;
               int nCountFit = nWidth / nCharWidth + 2/* wide char */;
-              if (nCount > nCountFit) {
+              if (nCount1 > nCountFit) {
 #ifndef _UNICODE
                 if (_ismbslead((unsigned char *)(LPCSTR)line, (unsigned char *)(LPCSTR)line + nCountFit - 1))
                   nCountFit++;
 #endif
-                nCount = nCountFit;
+                nCount1 = nCountFit;
               }
 
               // Table of charwidths as CCrystalEditor thinks they are
               // Seems that CrystalEditor's and ExtTextOut()'s charwidths aren't
               // same with some fonts and text is drawn only partially
               // if this table is not used.
-              vector<int> nWidths(nCount + 2);
-              for ( ; i < nCount + ibegin ; i++)
+              vector<int> nWidths(nCount1 + 2);
+              for ( ; i < nCount1 + ibegin ; i++)
                 {
                   if (line[i] == '\t') // Escape sequence leadin?
                   {
@@ -1149,7 +1149,7 @@ DrawLineHelperImpl (CDC * pdc, CPoint & ptOrigin, const CRect & rcClip,
                   RECT rcTextBlock = {ptOrigin.x, ptOrigin.y, ptOrigin.x + nSumWidth + 2, ptOrigin.y + nLineHeight};
                   IntersectRect(&rcIntersect, &rcClip, &rcTextBlock);
                   VERIFY(pdc->ExtTextOut(ptOrigin.x, ptOrigin.y, ETO_CLIPPED | ETO_OPAQUE,
-                      &rcIntersect, LPCTSTR(line) + ibegin, nCount, &nWidths[0]));
+                      &rcIntersect, LPCTSTR(line) + ibegin, nCount1, &nWidths[0]));
                   // Draw rounded rectangles around control characters
                   pdc->SaveDC();
                   pdc->IntersectClipRect(&rcClip);
@@ -1159,7 +1159,7 @@ DrawLineHelperImpl (CDC * pdc, CPoint & ptOrigin, const CRect & rcClip,
                   HGDIOBJ hPen = ::CreatePen(PS_SOLID, 1, ::GetTextColor(hDC));
                   hPen = ::SelectObject(hDC, hPen);
                   int x = ptOrigin.x;
-                  for (int j = 0 ; j < nCount ; ++j)
+                  for (int j = 0 ; j < nCount1 ; ++j)
                   {
                     // Assume narrowed space is converted escape sequence leadin.
                     if (line[ibegin + j] == ' ' && nWidths[j] < nCharWidth)
@@ -5452,15 +5452,15 @@ OnFilePageSetup ()
     }
   if (dlg.DoModal () == IDOK)
     {
-      CReg reg;
-      if (reg.Create (HKEY_CURRENT_USER, REG_EDITPAD, KEY_WRITE))
+      CReg reg1;
+      if (reg1.Create (HKEY_CURRENT_USER, REG_EDITPAD, KEY_WRITE))
         {
-          VERIFY (reg.SaveNumber (_T ("PageWidth"), dlg.m_psd.ptPaperSize.x));
-          VERIFY (reg.SaveNumber (_T ("PageHeight"), dlg.m_psd.ptPaperSize.y));
-          VERIFY (reg.SaveNumber (_T ("PageLeft"), dlg.m_psd.rtMargin.left));
-          VERIFY (reg.SaveNumber (_T ("PageRight"), dlg.m_psd.rtMargin.right));
-          VERIFY (reg.SaveNumber (_T ("PageTop"), dlg.m_psd.rtMargin.top));
-          VERIFY (reg.SaveNumber (_T ("PageBottom"), dlg.m_psd.rtMargin.bottom));
+          VERIFY (reg1.SaveNumber (_T ("PageWidth"), dlg.m_psd.ptPaperSize.x));
+          VERIFY (reg1.SaveNumber (_T ("PageHeight"), dlg.m_psd.ptPaperSize.y));
+          VERIFY (reg1.SaveNumber (_T ("PageLeft"), dlg.m_psd.rtMargin.left));
+          VERIFY (reg1.SaveNumber (_T ("PageRight"), dlg.m_psd.rtMargin.right));
+          VERIFY (reg1.SaveNumber (_T ("PageTop"), dlg.m_psd.rtMargin.top));
+          VERIFY (reg1.SaveNumber (_T ("PageBottom"), dlg.m_psd.rtMargin.bottom));
         }
       pApp->SelectPrinter (dlg.m_psd.hDevNames, dlg.m_psd.hDevMode, false);
     }

--- a/Externals/crystaledit/editlib/ccrystaltextview2.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview2.cpp
@@ -175,7 +175,7 @@ MoveWordLeft (bool bSelect)
 
   if (nPos > 0)
     {
-      int nPrevPos = (int) (::CharPrev(pszChars, pszChars + nPos) - pszChars);
+      nPrevPos = (int) (::CharPrev(pszChars, pszChars + nPos) - pszChars);
       nPos = nPrevPos;
       if (xisalnum (pszChars[nPos]))
         {
@@ -830,7 +830,7 @@ OnLButtonUp (UINT nFlags, CPoint point)
       AdjustTextPoint (point);
       CPoint ptNewCursorPos = ClientToText (point);
 
-      CPoint ptStart, ptEnd;
+	  CPoint ptStart;
       if (m_bLineSelection)
         {
           CPoint ptEnd;
@@ -882,6 +882,7 @@ OnLButtonUp (UINT nFlags, CPoint point)
         }
       else
         {
+		  CPoint ptEnd;
           if (m_bWordSelection)
             {
               if (ptNewCursorPos.y < m_ptAnchor.y ||

--- a/Externals/crystaledit/editlib/registry.cpp
+++ b/Externals/crystaledit/editlib/registry.cpp
@@ -142,34 +142,34 @@ RegValGetStringArr (const RegVal *pValData, LPTSTR pszStrings[], DWORD dwCount)
   ASSERT (pValData);
   if (pValData->dwType == REG_MULTI_SZ)
     {
-      LPCTSTR pszString;
+      LPCTSTR pszString0;
       DWORD dwRealCount = 0, dwLength;
-      for (pszString = pValData->pszString; *pszString; pszString += dwLength)
+      for (pszString0 = pValData->pszString; *pszString0; pszString0 += dwLength)
         {
-          dwLength = (DWORD) _tcslen (pszString) + 1;
+          dwLength = (DWORD) _tcslen (pszString0) + 1;
           dwRealCount++;
         }
       if (dwCount >= dwRealCount)
         {
           LPTSTR *pszDstString = pszStrings;
-          for (LPCTSTR pszString = pValData->pszString; *pszString; pszString += dwLength, pszDstString++)
+          for (LPCTSTR pszString1 = pValData->pszString; *pszString1; pszString1 += dwLength, pszDstString++)
             {
-              dwLength = (DWORD) _tcslen (pszString) + 1;
+              dwLength = (DWORD) _tcslen (pszString1) + 1;
               LPTSTR pszNewString = (LPTSTR) malloc (dwLength);
               *pszDstString = pszNewString;
               if (pszNewString)
                 {
-                  while ((*pszNewString = (BYTE) *pszString) != _T ('\0'))
+                  while ((*pszNewString = (BYTE) *pszString1) != _T ('\0'))
                     {
                       pszNewString++;
-                      pszString++;
+                      pszString1++;
                     }
                 }
               else
                 {
-                  while (*pszString)
+                  while (*pszString1)
                     {
-                      pszString++;
+                      pszString1++;
                     }
                 }
             }

--- a/Externals/poco/Foundation/Foundation.vs2015.vcxproj
+++ b/Externals/poco/Foundation/Foundation.vs2015.vcxproj
@@ -98,6 +98,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -127,6 +128,7 @@
       <ProgramDataBaseFileName>..\lib64\PocoFoundationmtd.pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -149,7 +151,7 @@
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -160,6 +162,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -182,7 +185,7 @@
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -193,6 +196,7 @@
       <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Externals/poco/Foundation/Foundation.vs2017.vcxproj
+++ b/Externals/poco/Foundation/Foundation.vs2017.vcxproj
@@ -98,6 +98,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -127,6 +128,7 @@
       <ProgramDataBaseFileName>..\lib64\PocoFoundationmtd.pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -149,7 +151,7 @@
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -160,6 +162,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -182,7 +185,7 @@
       <PreprocessKeepComments>false</PreprocessKeepComments>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -193,6 +196,7 @@
       <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Externals/poco/Foundation/include/Poco/ScopedLock.h
+++ b/Externals/poco/Foundation/include/Poco/ScopedLock.h
@@ -55,12 +55,12 @@ class ScopedLock
 	/// The destructor unlocks the mutex.
 {
 public:
-	explicit ScopedLock(M& mutex): _mutex(mutex)
+	explicit ScopedLock(M& rmutex): _mutex(rmutex)
 	{
 		_mutex.lock();
 	}
 	
-	ScopedLock(M& mutex, long milliseconds): _mutex(mutex)
+	ScopedLock(M& rmutex, long milliseconds): _mutex(rmutex)
 	{
 		_mutex.lock(milliseconds);
 	}

--- a/Externals/poco/Foundation/src/EventLogChannel.cpp
+++ b/Externals/poco/Foundation/src/EventLogChannel.cpp
@@ -288,9 +288,9 @@ std::wstring EventLogChannel::findLibrary(const wchar_t* name)
 	HMODULE dll = LoadLibraryW(name);
 	if (dll)
 	{
-		wchar_t name[MAX_PATH + 1];
-		int n = GetModuleFileNameW(dll, name, sizeof(name));
-		if (n > 0) path = name;
+		wchar_t name1[MAX_PATH + 1];
+		int n = GetModuleFileNameW(dll, name1, sizeof(name1));
+		if (n > 0) path = name1;
 		FreeLibrary(dll);
 	}
 	return path;

--- a/Externals/poco/Foundation/src/StreamConverter.cpp
+++ b/Externals/poco/Foundation/src/StreamConverter.cpp
@@ -133,10 +133,10 @@ int StreamConverterBuf::writeToDevice(char c)
 				++_errors;
 				return -1;
 			}
-			int n = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
-			if (n == 0) n = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
-			poco_assert_dbg (n <= sizeof(_buffer));
-			_pOstr->write((char*) _buffer, n);
+			int n1 = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
+			if (n1 == 0) n1 = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
+			poco_assert_dbg (n1 <= sizeof(_buffer));
+			_pOstr->write((char*) _buffer, n1);
 			_sequenceLength = 0;
 			_pos = 0;
 		}

--- a/Externals/poco/Foundation/src/pcre_compile.c
+++ b/Externals/poco/Foundation/src/pcre_compile.c
@@ -2382,7 +2382,7 @@ static BOOL
 get_othercase_range(unsigned int *cptr, unsigned int d, unsigned int *ocptr,
   unsigned int *odptr)
 {
-unsigned int c, othercase, next;
+unsigned int c, othercase=0, next;
 
 for (c = *cptr; c <= d; c++)
   { if ((othercase = UCD_OTHERCASE(c)) != c) break; }

--- a/Externals/poco/Util/Util.vs2015.vcxproj
+++ b/Externals/poco/Util/Util.vs2015.vcxproj
@@ -97,6 +97,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmtd.lib</OutputFile>
@@ -125,6 +126,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmtd.lib</OutputFile>
@@ -143,7 +145,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;_STATIC_CPPLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -154,6 +156,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmt.lib</OutputFile>
@@ -172,7 +175,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;_STATIC_CPPLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -183,6 +186,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmt.lib</OutputFile>

--- a/Externals/poco/Util/Util.vs2017.vcxproj
+++ b/Externals/poco/Util/Util.vs2017.vcxproj
@@ -97,6 +97,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmtd.lib</OutputFile>
@@ -125,6 +126,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmtd.lib</OutputFile>
@@ -143,7 +145,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;_STATIC_CPPLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -154,6 +156,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmt.lib</OutputFile>
@@ -172,7 +175,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;_STATIC_CPPLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -183,6 +186,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmt.lib</OutputFile>

--- a/Externals/poco/Util/src/AbstractConfiguration.cpp
+++ b/Externals/poco/Util/src/AbstractConfiguration.cpp
@@ -352,10 +352,10 @@ std::string AbstractConfiguration::uncheckedExpand(const std::string& value) con
 				std::string prop;
 				while (it != end && *it != '}') prop += *it++;
 				if (it != end) ++it;
-				std::string value;
-				if (getRaw(prop, value))
+				std::string value1;
+				if (getRaw(prop, value1))
 				{
-					result.append(internalExpand(value));
+					result.append(internalExpand(value1));
 				}
 				else
 				{

--- a/Externals/poco/XML/XML.vs2015.vcxproj
+++ b/Externals/poco/XML/XML.vs2015.vcxproj
@@ -97,6 +97,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmtd.lib</OutputFile>
@@ -125,6 +126,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmtd.lib</OutputFile>
@@ -142,7 +144,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;XML_STATIC;_STATIC_CPPLIB;XML_NS;XML_DTD;HAVE_EXPAT_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -153,6 +155,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmt.lib</OutputFile>
@@ -171,7 +174,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;XML_STATIC;_STATIC_CPPLIB;XML_NS;XML_DTD;HAVE_EXPAT_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -182,6 +185,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmt.lib</OutputFile>

--- a/Externals/poco/XML/XML.vs2017.vcxproj
+++ b/Externals/poco/XML/XML.vs2017.vcxproj
@@ -97,6 +97,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmtd.lib</OutputFile>
@@ -125,6 +126,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmtd.lib</OutputFile>
@@ -142,7 +144,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;XML_STATIC;_STATIC_CPPLIB;XML_NS;XML_DTD;HAVE_EXPAT_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -153,6 +155,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmt.lib</OutputFile>
@@ -171,7 +174,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;XML_STATIC;_STATIC_CPPLIB;XML_NS;XML_DTD;HAVE_EXPAT_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -182,6 +185,7 @@
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmt.lib</OutputFile>

--- a/Externals/poco/XML/src/xmlparse.cpp
+++ b/Externals/poco/XML/src/xmlparse.cpp
@@ -1646,14 +1646,14 @@ XML_GetBuffer(XML_Parser parser, int len)
       bufferLim = newBuf + bufferSize;
 #ifdef XML_CONTEXT_BYTES
       if (bufferPtr) {
-        int keep = (int)(bufferPtr - buffer);
-        if (keep > XML_CONTEXT_BYTES)
-          keep = XML_CONTEXT_BYTES;
-        memcpy(newBuf, &bufferPtr[-keep], bufferEnd - bufferPtr + keep);
+        int keep1 = (int)(bufferPtr - buffer);
+        if (keep1 > XML_CONTEXT_BYTES)
+          keep1 = XML_CONTEXT_BYTES;
+        memcpy(newBuf, &bufferPtr[-keep1], bufferEnd - bufferPtr + keep1);
         FREE(buffer);
         buffer = newBuf;
-        bufferEnd = buffer + (bufferEnd - bufferPtr) + keep;
-        bufferPtr = buffer + keep;
+        bufferEnd = buffer + (bufferEnd - bufferPtr) + keep1;
+        bufferPtr = buffer + keep1;
       }
       else {
         bufferEnd = newBuf + (bufferEnd - bufferPtr);
@@ -4313,16 +4313,16 @@ doProlog(XML_Parser parser,
     case XML_ROLE_GROUP_OPEN:
       if (prologState.level >= groupSize) {
         if (groupSize) {
-          char *temp = (char *)REALLOC(groupConnector, groupSize *= 2);
-          if (temp == NULL)
+          char *temp1 = (char *)REALLOC(groupConnector, groupSize *= 2);
+          if (temp1 == NULL)
             return XML_ERROR_NO_MEMORY;
-          groupConnector = temp;
+          groupConnector = temp1;
           if (dtd->scaffIndex) {
-            int *temp = (int *)REALLOC(dtd->scaffIndex,
+            int *temp2 = (int *)REALLOC(dtd->scaffIndex,
                           groupSize * sizeof(int));
-            if (temp == NULL)
+            if (temp2 == NULL)
               return XML_ERROR_NO_MEMORY;
-            dtd->scaffIndex = temp;
+            dtd->scaffIndex = temp2;
           }
         }
         else {

--- a/Src/Common/BCMenu.cpp
+++ b/Src/Common/BCMenu.cpp
@@ -277,11 +277,11 @@ void BCMenu::DrawItem_Win9xNT2000 (LPDRAWITEMSTRUCT lpDIS)
 	ASSERT(lpDIS != NULL);
 	CDC* pDC = CDC::FromHandle(lpDIS->hDC);
 	CRect rect;
-	UINT state = reinterpret_cast<BCMenuData*>(lpDIS->itemData)->nFlags;
+	UINT state0 = reinterpret_cast<BCMenuData*>(lpDIS->itemData)->nFlags;
 	COLORREF clrBack=GetSysColor(COLOR_MENU);
 	CBrush brBackground(clrBack);
 
-	if(state & MF_SEPARATOR){
+	if(state0 & MF_SEPARATOR){
 		rect.CopyRect(&lpDIS->rcItem);
 		pDC->FillRect (rect,&brBackground);
 		rect.top += (rect.Height()>>1);

--- a/Src/Common/LanguageSelect.cpp
+++ b/Src/Common/LanguageSelect.cpp
@@ -683,24 +683,24 @@ BOOL CLanguageSelect::LoadLanguageFile(LANGID wLangId, BOOL bShowError)
 	std::string directive;
 	while (fgets(buf, sizeof buf, f))
 	{
-		if (char *p = EatPrefix(buf, "#:"))
+		if (char *p0 = EatPrefix(buf, "#:"))
 		{
-			if (char *q = strchr(p, ':'))
+			if (char *q = strchr(p0, ':'))
 			{
 				uid = strtoul(q + 1, &q, 16);
 				found_uid = true;
 				--unresolved;
 			}
 		}
-		else if (char *p = EatPrefix(buf, "#,"))
+		else if (char *p1 = EatPrefix(buf, "#,"))
 		{
-			format = p;
+			format = p1;
 			format.erase(0, format.find_first_not_of(" \t\r\n"));
 			format.erase(format.find_last_not_of(" \t\r\n") + 1);
 		}
-		else if (char *p = EatPrefix(buf, "#."))
+		else if (char *p2 = EatPrefix(buf, "#."))
 		{
-			directive = p;
+			directive = p2;
 			directive.erase(0, directive.find_first_not_of(" \t\r\n"));
 			directive.erase(directive.find_last_not_of(" \t\r\n") + 1);
 		}
@@ -905,8 +905,8 @@ void CLanguageSelect::SetIndicators(CStatusBar &sb, const UINT *rgid, int n) con
 		if (id >= ID_INDICATOR_EXT)
 		{
 			String text = LoadString(id);
-			int cx = dc.GetTextExtent(text.c_str(), static_cast<int>(text.length())).cx;
-			sb.SetPaneInfo(i, id, style | SBPS_DISABLED, cx);
+			int cx1 = dc.GetTextExtent(text.c_str(), static_cast<int>(text.length())).cx;
+			sb.SetPaneInfo(i, id, style | SBPS_DISABLED, cx1);
 			sb.SetPaneText(i, text.c_str(), FALSE);
 		}
 		else if (rgid)

--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -178,17 +178,17 @@ void CMDITabBar::OnContextMenu(CWnd *pWnd, CPoint point)
 	case ID_CLOSE_LEFT_TABS: {
 		int curcel = GetCurSel();
 		int n = GetItemCount();
-		TCITEM tci;
-		tci.mask = TCIF_PARAM;
+		TCITEM tci1;
+		tci1.mask = TCIF_PARAM;
 		for (int i = n - 1; i >= 0; --i)
 		{
 			if ((command == ID_CLOSE_OTHER_TABS && i == curcel) ||
 				(command == ID_CLOSE_RIGHT_TABS && i <= curcel) ||
 				(command == ID_CLOSE_LEFT_TABS  && i >= curcel))
 				continue;
-			GetItem(i, &tci);
-			CWnd* pMDIChild = FromHandle((HWND)tci.lParam);
-			pMDIChild->SendMessage(WM_SYSCOMMAND, SC_CLOSE);
+			GetItem(i, &tci1);
+			CWnd* pMDIChild1 = FromHandle((HWND)tci1.lParam);
+			pMDIChild1->SendMessage(WM_SYSCOMMAND, SC_CLOSE);
 		}
 		break;
 	}
@@ -244,7 +244,7 @@ void CMDITabBar::UpdateTabs()
 	for (POSITION pos = MDIFrameList.GetStartPosition(); pos; )
 	{
 		HWND hFrameWnd;
-		int item;
+//~		int item;
 		MDIFrameList.GetNextAssoc(pos, hFrameWnd, item);
 
 		CString strTitle;
@@ -368,10 +368,10 @@ void CMDITabBar::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 		CPoint pt;
 		GetCursorPos(&pt);
 		ScreenToClient(&pt);
-		CRect rc = GetCloseButtonRect(nItem);
-		DrawFrameControl(lpDraw->hDC, &rc, DFC_CAPTION, 
-			DFCS_CAPTIONCLOSE | DFCS_FLAT | (rc.PtInRect(pt) ? DFCS_HOT : 0) |
-			((m_bCloseButtonDown && rc.PtInRect(pt)) ? DFCS_PUSHED : 0));
+		CRect rc1 = GetCloseButtonRect(nItem);
+		DrawFrameControl(lpDraw->hDC, &rc1, DFC_CAPTION, 
+			DFCS_CAPTIONCLOSE | DFCS_FLAT | (rc1.PtInRect(pt) ? DFCS_HOT : 0) |
+			((m_bCloseButtonDown && rc1.PtInRect(pt)) ? DFCS_PUSHED : 0));
 	}
 }
 

--- a/Src/Common/OptionsMgr.cpp
+++ b/Src/Common/OptionsMgr.cpp
@@ -218,7 +218,7 @@ bool COption::ConvertString(varprop::VariantValue & value, varprop::VT_TYPE nTyp
 	case varprop::VT_BOOL:
 		// Convert string to boolean
 		{
-			std::transform(svalue.begin(), svalue.end(), svalue.begin(), ::tolower);
+			svalue = strutils::makelower(svalue);
 			if (svalue == _T("1") || svalue == _T("yes")
 				|| svalue == _T("true"))
 			{

--- a/Src/Common/PropertyPageHost.cpp
+++ b/Src/Common/PropertyPageHost.cpp
@@ -153,13 +153,13 @@ BOOL CPropertyPageHost::SetActivePage(int nIndex, BOOL bAndFocus)
 
 	if (m_nSelIndex != -1)
 	{
-		CPropertyPage* pPage = GetActivePage();
-		ASSERT (pPage);
+		CPropertyPage* pPage1 = GetActivePage();
+		ASSERT (pPage1);
 
-		if (pPage)
+		if (pPage1)
 		{
-			pPage->ShowWindow(SW_HIDE);
-			pPage->OnKillActive();
+			pPage1->ShowWindow(SW_HIDE);
+			pPage1->OnKillActive();
 		}
 	}
 

--- a/Src/Common/SplitterWndEx.cpp
+++ b/Src/Common/SplitterWndEx.cpp
@@ -208,7 +208,7 @@ void CSplitterWndEx::EqualizeCols()
 
 	int i;
 	int sum = 0;
-	int hmin;
+	int hmin = 0;
 
 	for (i = 0 ; i < m_nCols ; i++)
 	{

--- a/Src/Common/UniFile.cpp
+++ b/Src/Common/UniFile.cpp
@@ -618,10 +618,10 @@ bool UniMemFile::ReadString(String & line, String & eol, bool * lossy)
 		}
 		// convert from Unicode codepoint to TCHAR string
 		// could be multicharacter if decomposition took place, for example
-		bool lossy = false; // try to avoid lossy conversion
+		bool lossy1 = false; // try to avoid lossy conversion
 		String sch;
-		ucr::maketchar(sch, ch, lossy);
-		if (lossy)
+		ucr::maketchar(sch, ch, lossy1);
+		if (lossy1)
 			++m_txtstats.nlosses;
 		if (sch.length() >= 1)
 			ch = sch[0];
@@ -637,10 +637,10 @@ bool UniMemFile::ReadString(String & line, String & eol, bool * lossy)
 			// check for crlf pair
 			if (m_current - m_base + 2 * m_charsize - 1 < m_filesize)
 			{
-				// For UTF-8, this ch will be wrong if character is non-ASCII
+				// For UTF-8, this ch1 will be wrong if character is non-ASCII
 				// but we only check it against \n here, so it doesn't matter
-				unsigned ch = ucr::get_unicode_char(m_current + m_charsize, (ucr::UNICODESET)m_unicoding);
-				if (ch == '\n')
+				unsigned ch1 = ucr::get_unicode_char(m_current + m_charsize, (ucr::UNICODESET)m_unicoding);
+				if (ch1 == '\n')
 				{
 					crlf = true;
 				}

--- a/Src/Common/lwdisp.c
+++ b/Src/Common/lwdisp.c
@@ -367,6 +367,7 @@ STDAPI invokeV(LPDISPATCH pi, VARIANT *ret, DISPID id, LPCCH op, VARIANT *argv)
 	EXCEPINFO excepInfo = {0};
 	dispparams.cArgs = LOBYTE((UINT_PTR)op);
 	dispparams.cNamedArgs = 0;
+	dispparams.rgvarg = argv;
 	if (wFlags & (DISPATCH_PROPERTYPUT|DISPATCH_PROPERTYPUTREF))
 	{
 		dispparams.cNamedArgs = 1;

--- a/Src/Common/multiformatText.cpp
+++ b/Src/Common/multiformatText.cpp
@@ -278,7 +278,7 @@ const TCHAR *storageForPlugins::GetDataFileUnicode()
 			int bom_bytes = 0;
 			{
 				SharedMemory shmOut(fileOut, SharedMemory::AM_WRITE);
-				int bom_bytes = ucr::writeBom(shmOut.begin(), ucr::UCS2LE);
+				bom_bytes = ucr::writeBom(shmOut.begin(), ucr::UCS2LE);
 				// to UCS-2 conversion, from unicoder.cpp maketstring
 				bool lossy;
 				textRealSize = ucr::CrossConvert(pchar, nchars, (char *)shmOut.begin()+bom_bytes, textForeseenSize-1, m_codepage, ucr::CP_UCS2LE, &lossy);
@@ -570,7 +570,6 @@ static const char *findNextLine(ucr::UNICODESET unicoding, const char *pstart, c
 	default:
 		return findNextLine<char, false>(pstart, pend);
 	}
-	return pend;
 }
 
 bool AnyCodepageToUTF8(int codepage, const String& filepath, const String& filepathDst, int & nFileChanged, bool bWriteBOM)

--- a/Src/Common/sizecbar.cpp
+++ b/Src/Common/sizecbar.cpp
@@ -767,13 +767,13 @@ void CSizingControlBar::OnTrackUpdateSize(CPoint& point)
 
         for (int i = nFirst; nDelta != 0 && i != nLimit; i += (bBefore ? -1 : 1))
         {
-            CSizingControlBar* pBar = arrSCBars[i];
+            CSizingControlBar* pBar1 = arrSCBars[i];
                 
             int nDeltaT = min(nDelta,
-                (bHorz ? pBar->m_szHorz.cx : pBar->m_szVert.cy) -
-                (bHorz ? pBar->m_szMinHorz.cx : pBar->m_szMinVert.cy));
+                (bHorz ? pBar1->m_szHorz.cx : pBar1->m_szVert.cy) -
+                (bHorz ? pBar1->m_szMinHorz.cx : pBar1->m_szMinVert.cy));
 
-            (bHorz ? pBar->m_szHorz.cx : pBar->m_szVert.cy) -= nDeltaT;
+            (bHorz ? pBar1->m_szHorz.cx : pBar1->m_szVert.cy) -= nDeltaT;
             nDelta -= nDeltaT;
         }
     }

--- a/Src/Common/unicoder.cpp
+++ b/Src/Common/unicoder.cpp
@@ -512,7 +512,7 @@ bool maketstring(String & str, const char* lpd, size_t len, int codepage, bool *
 		{
 			if (GetLastError() == ERROR_INVALID_FLAGS)
 			{
-				int n = MultiByteToWideChar(codepage, 0, lpd, static_cast<int>(len), wbuff, static_cast<int>(wlen-1));
+				n = MultiByteToWideChar(codepage, 0, lpd, static_cast<int>(len), wbuff, static_cast<int>(wlen-1));
 				if (n)
 				{
 					/* NB: MultiByteToWideChar is documented as only zero-terminating 

--- a/Src/CompareOptions.h
+++ b/Src/CompareOptions.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include "diff.h"
+
 /**
  * @brief Whether to ignore whitespace (or to ignore changes in whitespace)
  *
@@ -37,27 +39,29 @@ enum WhitespaceIgnoreChoices
  */
 enum DiffOutputType
 {
+	// NOTE: these values are stored in the user's Registry - don't change their value !!
 	/**< Default output style.  */
-	DIFF_OUTPUT_NORMAL,
+	DIFF_OUTPUT_NORMAL = OUTPUT_NORMAL,
 	/**< Output the differences with lines of context before and after (-c).  */
-	DIFF_OUTPUT_CONTEXT,
+	DIFF_OUTPUT_CONTEXT = OUTPUT_CONTEXT,
 	/**< Output the differences in a unified context diff format (-u). */
-	DIFF_OUTPUT_UNIFIED,
-	/** Output html style.  */
-	DIFF_OUTPUT_HTML = 8,
+	DIFF_OUTPUT_UNIFIED = OUTPUT_UNIFIED,
 // These are not used, see the comment above enum.
 #if 0
 	/**< Output the differences as commands suitable for `ed' (-e).  */
-	DIFF_OUTPUT_ED,
+	DIFF_OUTPUT_ED = OUTPUT_ED,
 	/**< Output the diff as a forward ed script (-f).  */
-	DIFF_OUTPUT_FORWARD_ED,
+	DIFF_OUTPUT_FORWARD_ED = OUTPUT_FORWARD_ED,
 	/**< Like -f, but output a count of changed lines in each "command" (-n). */
-	DIFF_OUTPUT_RCS,
+	DIFF_OUTPUT_RCS = OUTPUT_RCS,
 	/**< Output merged #ifdef'd file (-D).  */
-	DIFF_OUTPUT_IFDEF,
+	DIFF_OUTPUT_IFDEF = OUTPUT_IFDEF,
 	/**< Output sdiff style (-y).  */
-	DIFF_OUTPUT_SDIFF,
+	DIFF_OUTPUT_SDIFF = OUTPUT_SDIFF,
 #endif
+//  ... end of unused
+	/** Output html style.  */
+	DIFF_OUTPUT_HTML = OUTPUT_HTML,
 };
 
 /**

--- a/Src/Diff3.h
+++ b/Src/Diff3.h
@@ -215,14 +215,14 @@ size_t Make3wayDiff(std::vector<Element>& diff3, const std::vector<Element>& dif
 	
 	for (size_t i = 0; i < diff3i; i++)
 	{
-		Element& dr3 = diff3.at(i);
+		Element& dr3r = diff3.at(i);
 		if (i < diff3i - 1)
 		{
 			Element& dr3next = diff3.at(i + 1);
 			for (int j = 0; j < 3; j++)
 			{
-				if (dr3.end[j] >= dr3next.begin[j])
-					dr3.end[j] = dr3next.begin[j] - 1;
+				if (dr3r.end[j] >= dr3next.begin[j])
+					dr3r.end[j] = dr3next.begin[j] - 1;
 			}
 		}
 	}

--- a/Src/DiffFileData.cpp
+++ b/Src/DiffFileData.cpp
@@ -165,8 +165,8 @@ bool DiffFileData::Filepath_Transform(bool bForceUTF8,
 	{
 		// fourth step : prepare for diffing
 		// may overwrite if we've already copied to temp file
-		bool bMayOverwrite = 0 != strutils::compare_nocase(filepathTransformed, filepath);
-		if (!FileTransform::AnyCodepageToUTF8(encoding.m_codepage, filepathTransformed, bMayOverwrite))
+		bool bMayOverwrite1 = 0 != strutils::compare_nocase(filepathTransformed, filepath);
+		if (!FileTransform::AnyCodepageToUTF8(encoding.m_codepage, filepathTransformed, bMayOverwrite1))
 			return false;
 	}
 	return true;

--- a/Src/DiffTextBuffer.cpp
+++ b/Src/DiffTextBuffer.cpp
@@ -628,9 +628,9 @@ int CDiffTextBuffer::SaveToFile (const String& pszFileName,
 		// Write tempfile over original file
 		try
 		{
-			TFile file(sIntermediateFilename);
-			file.copyTo(pszFileName);
-			file.remove();
+			TFile file1(sIntermediateFilename);
+			file1.copyTo(pszFileName);
+			file1.remove();
 			if (bClearModifiedFlag)
 			{
 				SetModified(false);

--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -458,9 +458,9 @@ bool CDiffWrapper::PostFilter(int StartPos, int EndPos, int Direction,
 				int TrivLinePos = i+1;
 				for(; TrivLinePos != (StartPos + QtyLinesInBlock);++TrivLinePos)
 				{
-					size_t len = files[FileNo].linbuf[TrivLinePos + 1] - files[FileNo].linbuf[TrivLinePos];
+					size_t len1 = files[FileNo].linbuf[TrivLinePos + 1] - files[FileNo].linbuf[TrivLinePos];
 					const char *LineStrTrvCk = files[FileNo].linbuf[TrivLinePos];
-					std::string LineDataTrvCk(LineStrTrvCk, linelen(LineStrTrvCk, len));
+					std::string LineDataTrvCk(LineStrTrvCk, linelen(LineStrTrvCk, len1));
 					if (LineDataTrvCk.size() &&
 						!IsTrivialBytes(LineDataTrvCk.c_str(), LineDataTrvCk.c_str() + LineDataTrvCk.size(), filtercommentsset))
 					{
@@ -1333,7 +1333,7 @@ CDiffWrapper::LoadWinMergeDiffsFromDiffUtilsScript3(
 	const file_data * inf10, 
 	const file_data * inf12)
 {
-	DiffList diff10, diff12, *pdiff;
+	DiffList diff10, diff12;
 	diff10.Clear();
 	diff12.Clear();
 

--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -1000,30 +1000,32 @@ String CDiffWrapper::FormatSwitchString() const
 	
 	switch (m_options.m_outputStyle)
 	{
-	case OUTPUT_CONTEXT:
-		switches = _T(" C");
-		break;
-	case OUTPUT_UNIFIED:
-		switches = _T(" U");
-		break;
-	case OUTPUT_ED:
-		switches = _T(" e");
-		break;
-	case OUTPUT_FORWARD_ED:
-		switches = _T(" f");
-		break;
-	case OUTPUT_RCS:
-		switches = _T(" n");
-		break;
-	case OUTPUT_NORMAL:
+	case DIFF_OUTPUT_NORMAL:
 		switches = _T(" ");
 		break;
-	case OUTPUT_IFDEF:
+	case DIFF_OUTPUT_CONTEXT:
+		switches = _T(" C");
+		break;
+	case DIFF_OUTPUT_UNIFIED:
+		switches = _T(" U");
+		break;
+#if 0
+	case DIFF_OUTPUT_ED:
+		switches = _T(" e");
+		break;
+	case DIFF_OUTPUT_FORWARD_ED:
+		switches = _T(" f");
+		break;
+	case DIFF_OUTPUT_RCS:
+		switches = _T(" n");
+		break;
+	case DIFF_OUTPUT_IFDEF:
 		switches = _T(" D");
 		break;
-	case OUTPUT_SDIFF:
+	case DIFF_OUTPUT_SDIFF:
 		switches = _T(" y");
 		break;
+#endif
 	}
 
 	if (m_options.m_contextLines > 0)
@@ -1453,14 +1455,16 @@ void CDiffWrapper::WritePatchFileHeader(enum output_style output_style, bool bAp
 	// Output patchfile
 	switch (output_style)
 	{
+	case OUTPUT_NORMAL:
 	case OUTPUT_CONTEXT:
 	case OUTPUT_UNIFIED:
+#if 0
 	case OUTPUT_ED:
 	case OUTPUT_FORWARD_ED:
 	case OUTPUT_RCS:
-	case OUTPUT_NORMAL:
 	case OUTPUT_IFDEF:
 	case OUTPUT_SDIFF:
+#endif
 		break;
 	case OUTPUT_HTML:
 		print_html_header();
@@ -1489,14 +1493,16 @@ void CDiffWrapper::WritePatchFileTerminator(enum output_style output_style)
 	// Output patchfile
 	switch (output_style)
 	{
+	case OUTPUT_NORMAL:
 	case OUTPUT_CONTEXT:
 	case OUTPUT_UNIFIED:
+#if 0
 	case OUTPUT_ED:
 	case OUTPUT_FORWARD_ED:
 	case OUTPUT_RCS:
-	case OUTPUT_NORMAL:
 	case OUTPUT_IFDEF:
 	case OUTPUT_SDIFF:
+#endif
 		break;
 	case OUTPUT_HTML:
 		print_html_terminator();
@@ -1584,6 +1590,9 @@ void CDiffWrapper::WritePatchFile(struct change * script, file_data * inf)
 	// Output patchfile
 	switch (output_style)
 	{
+	case OUTPUT_NORMAL:
+		print_normal_script(script);
+		break;
 	case OUTPUT_CONTEXT:
 		print_context_header(inf_patch, 0);
 		print_context_script(script, 0);
@@ -1592,6 +1601,7 @@ void CDiffWrapper::WritePatchFile(struct change * script, file_data * inf)
 		print_context_header(inf_patch, 1);
 		print_context_script(script, 1);
 		break;
+#if 0
 	case OUTPUT_ED:
 		print_ed_script(script);
 		break;
@@ -1601,15 +1611,13 @@ void CDiffWrapper::WritePatchFile(struct change * script, file_data * inf)
 	case OUTPUT_RCS:
 		print_rcs_script(script);
 		break;
-	case OUTPUT_NORMAL:
-		print_normal_script(script);
-		break;
 	case OUTPUT_IFDEF:
 		print_ifdef_script(script);
 		break;
 	case OUTPUT_SDIFF:
 		print_sdiff_script(script);
 		break;
+#endif
 	case OUTPUT_HTML:
 		print_html_diff_header(inf_patch);
 		print_html_script(script);

--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -1337,11 +1337,12 @@ CDiffWrapper::LoadWinMergeDiffsFromDiffUtilsScript3(
 
 	for (int file = 0; file < 2; file++)
 	{
-		struct change *next;
+		struct change *next = nullptr;
 		int trans_a0, trans_b0, trans_a1, trans_b1;
 		int first0, last0, first1, last1, deletes, inserts;
 		OP_TYPE op;
-		const file_data *pinf;
+		const file_data *pinf = nullptr;
+		DiffList *pdiff = nullptr;
 
 		switch (file)
 		{
@@ -1384,18 +1385,11 @@ CDiffWrapper::LoadWinMergeDiffsFromDiffUtilsScript3(
 					// Store information about these blocks in moved line info
 					if (GetDetectMovedBlocks())
 					{
-						int index1 = -1;
-						int index2 = -1;
-						MovedLines::ML_SIDE side1;
-						MovedLines::ML_SIDE side2;
-						if (file == 0 /* diff10 */)
-						{
-							index1 = 0;
-							index2 = 1;
-							side1 = MovedLines::SIDE_RIGHT;
-							side2 = MovedLines::SIDE_LEFT;
-						}
-						else if (file == 1 /* diff12 */)
+						int index1 = 0;  // defaults for (file == 0 /* diff10 */)
+						int index2 = 1;
+						MovedLines::ML_SIDE side1 = MovedLines::SIDE_RIGHT;
+						MovedLines::ML_SIDE side2 = MovedLines::SIDE_LEFT;
+						if (file == 1 /* diff12 */)
 						{
 							index1 = 2;
 							index2 = 1;

--- a/Src/DirItem.cpp
+++ b/Src/DirItem.cpp
@@ -84,7 +84,7 @@ bool DirItem::Update(const String &sFilePath)
 {
 	bool retVal = false;
 
-	size = -1;
+	size = DirItem::FILE_SIZE_NONE;
 	flags.reset();
 	mtime = 0;
 
@@ -135,7 +135,7 @@ void DirItem::ClearPartial()
 {
 	ctime = 0;
 	mtime = 0;
-	size = -1;
+	size = DirItem::FILE_SIZE_NONE;
 	version.Clear();
 	flags.reset();
 }

--- a/Src/DirItem.h
+++ b/Src/DirItem.h
@@ -27,6 +27,7 @@
 #include <boost/flyweight.hpp>
 #include "UnicodeString.h"
 #include "FileVersion.h"
+#include "stdint.h"
 
 /**
  * @brief Class for fileflags.
@@ -52,13 +53,14 @@ struct DirItem
 {
 	Poco::Timestamp ctime; /**< time of creation */
 	Poco::Timestamp mtime; /**< time of last modify */
-	Poco::File::FileSize size; /**< file size in bytes, -1 means file does not exist*/
+	Poco::File::FileSize size; /**< file size in bytes, FILE_SIZE_NONE (== -1) means file does not exist*/
 	boost::flyweight<String> filename; /**< filename for this item */
 	boost::flyweight<String> path; /**< full path (excluding filename) for the item */
 	FileVersion version; /**< string of fixed file version, eg, 1.2.3.4 */
 	FileFlags flags; /**< file attributes */
-
-	DirItem() : ctime(0), mtime(0), size(-1) { }
+	
+	enum : uint64_t { FILE_SIZE_NONE = UINT64_MAX };
+	DirItem() : ctime(0), mtime(0), size(DirItem::FILE_SIZE_NONE) { }
 	void SetFile(const String &fullPath);
 	String GetFile() const;
 	bool Update(const String &sFilePath);

--- a/Src/DirTravel.cpp
+++ b/Src/DirTravel.cpp
@@ -111,7 +111,7 @@ static void LoadFiles(const String& sDir, DirItemArray * dirs, DirItemArray * fi
 				ent.mtime = 0;
 
 			if (ff.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-				ent.size = -1;  // No size for directories
+				ent.size = DirItem::FILE_SIZE_NONE;  // No size for directories
 			else
 			{
 				ent.size = ((int64_t)ff.nFileSizeHigh << 32) + ff.nFileSizeLow;

--- a/Src/FileFilterMgr.cpp
+++ b/Src/FileFilterMgr.cpp
@@ -88,7 +88,7 @@ void FileFilterMgr::LoadFromDirectory(const String& dir, const String& szPattern
 				// caller specified a specific extension
 				// (This is really a workaround for brokenness in windows, which
 				//  doesn't screen correctly on extension in pattern)
-				std::string ext = filename.substr(filename.length() - extlen);
+				const std::string ext = filename.substr(filename.length() - extlen);
 				if (icompare(u8ext, ext) != 0)
 					return;
 			}

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1277,8 +1277,8 @@ void CImgMergeFrame::OnIdleUpdateCmdUI()
 		RGBQUAD color[3];
 		for (int pane = 0; pane < m_pImgMergeWindow->GetPaneCount(); ++pane)
 			color[pane] = m_pImgMergeWindow->GetPixelColor(pane, pt.x, pt.y);
-		double colorDistance01, colorDistance12;
-		colorDistance01 = m_pImgMergeWindow->GetColorDistance(0, 1, pt.x, pt.y);
+		double colorDistance01 = m_pImgMergeWindow->GetColorDistance(0, 1, pt.x, pt.y);
+		double colorDistance12 = 0;
 		if (m_pImgMergeWindow->GetPaneCount() == 3)
 			colorDistance12 = m_pImgMergeWindow->GetColorDistance(1, 2, pt.x, pt.y);
 

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -904,8 +904,8 @@ void CImgMergeFrame::UpdateHeaderSizes()
 		{
 			for (int pane = 0; pane < nPaneCount; pane++)
 			{
-				RECT rc = m_pImgMergeWindow->GetPaneWindowRect(pane);
-				w[pane] = rc.right - rc.left - 4;
+				RECT rc1 = m_pImgMergeWindow->GetPaneWindowRect(pane);
+				w[pane] = rc1.right - rc1.left - 4;
 				if (w[pane]<1) w[pane]=1; // Perry 2003-01-22 (I don't know why this happens)
 			}
 		}
@@ -1928,8 +1928,8 @@ void CImgMergeFrame::OnImgUseBackColor()
 		if (dialog.DoModal() == IDOK)
 		{
 			COLORREF clrBackColor = dialog.GetColor();
-			RGBQUAD backColor = {GetBValue(clrBackColor), GetGValue(clrBackColor), GetRValue(clrBackColor)};
-			m_pImgMergeWindow->SetBackColor(backColor);
+			RGBQUAD backColor1 = {GetBValue(clrBackColor), GetGValue(clrBackColor), GetRValue(clrBackColor)};
+			m_pImgMergeWindow->SetBackColor(backColor1);
 			m_pImgMergeWindow->SetUseBackColor(bUseBackColor);
 		}
 	}

--- a/Src/LocationView.cpp
+++ b/Src/LocationView.cpp
@@ -922,7 +922,6 @@ int CLocationView::IsInsideBar(const CRect& rc, const POINT& pt)
 void CLocationView::DrawVisibleAreaRect(CDC *pClientDC, int nTopLine, int nBottomLine)
 {
 	CMergeDoc* pDoc = GetDocument();
-	const int nScreenLines = pDoc->GetView(0)->GetScreenLines();
 	
 	if (nTopLine == -1)
 		nTopLine = pDoc->GetView(0)->GetTopSubLine();

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1793,11 +1793,11 @@ void CMainFrame::OnResizePanes()
 		if (bResize)
 			pFrame->UpdateSplitter();
 	}
-	else if (CHexMergeFrame *pFrame = DYNAMIC_DOWNCAST(CHexMergeFrame, pActiveFrame))
+	else if (CHexMergeFrame *pFrame1 = DYNAMIC_DOWNCAST(CHexMergeFrame, pActiveFrame))
 	{
-		pFrame->UpdateAutoPaneResize();
+		pFrame1->UpdateAutoPaneResize();
 		if (bResize)
-			pFrame->UpdateSplitter();
+			pFrame1->UpdateSplitter();
 	}
 }
 

--- a/Src/Merge.vs2015.vcxproj
+++ b/Src/Merge.vs2015.vcxproj
@@ -149,6 +149,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -207,6 +208,7 @@
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -261,6 +263,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -367,6 +370,7 @@
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -149,6 +149,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -207,6 +208,7 @@
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -261,6 +263,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -367,6 +370,7 @@
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1719,9 +1719,9 @@ void CMergeDoc::DoFileSave(int nBuffer)
 		// If DirDoc contains compare results
 		if (m_pDirDoc && m_pDirDoc->HasDiffs())
 		{
-			for (int nBuffer = 0; nBuffer < m_nBuffers; nBuffer++)
+			for (int nBuffer1 = 0; nBuffer1 < m_nBuffers; nBuffer1++)
 			{
-				if (m_bEditAfterRescan[nBuffer])
+				if (m_bEditAfterRescan[nBuffer1])
 				{
 					FlushAndRescan(false);
 					break;

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -344,7 +344,7 @@ int CMergeDoc::Rescan(bool &bBinary, IDENTLEVEL &identical,
 {
 	DIFFOPTIONS diffOptions = {0};
 	DiffFileInfo fileInfo;
-	bool diffSuccess;
+	bool diffSuccess = false;
 	int nResult = RESCAN_OK;
 	FileChange FileChanged[3] = {FileNoChange, FileNoChange, FileNoChange};
 	int nBuffer;

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -2856,7 +2856,7 @@ void CMergeEditView::OnWMGoto()
 
 	if (dlg.DoModal() == IDOK)
 	{
-		CMergeDoc * pDoc = GetDocument();
+		CMergeDoc * pDoc1 = GetDocument();
 		CMergeEditView * pCurrentView = NULL;
 
 		// Get views
@@ -2867,21 +2867,21 @@ void CMergeEditView::OnWMGoto()
 
 		if (dlg.m_nGotoWhat == 0)
 		{
-			int nRealLine = num;
-			if (nRealLine < 0)
-				nRealLine = 0;
-			if (nRealLine > nLastLine)
-				nRealLine = nLastLine;
+			int nRealLine1 = num;
+			if (nRealLine1 < 0)
+				nRealLine1 = 0;
+			if (nRealLine1 > nLastLine)
+				nRealLine1 = nLastLine;
 
-			GotoLine(nRealLine, true, (pDoc->m_nBuffers < 3) ? (dlg.m_nFile == 2 ? 1 : 0) : dlg.m_nFile);
+			GotoLine(nRealLine1, true, (pDoc1->m_nBuffers < 3) ? (dlg.m_nFile == 2 ? 1 : 0) : dlg.m_nFile);
 		}
 		else
 		{
 			int diff = num;
 			if (diff < 0)
 				diff = 0;
-			if (diff >= pDoc->m_diffList.GetSize())
-				diff = pDoc->m_diffList.GetSize();
+			if (diff >= pDoc1->m_diffList.GetSize())
+				diff = pDoc1->m_diffList.GetSize();
 
 			pCurrentView->SelectDiff(diff, true, false);
 		}
@@ -3154,9 +3154,9 @@ void CMergeEditView::GotoLine(UINT nLine, bool bRealLine, int pane)
 		}
 		else
 		{
-			CPoint ptPos(0, pView->GetLineCount() - 1);
-			pView->SetCursorPos(ptPos);
-			pView->SetAnchor(ptPos);
+			CPoint ptPos1(0, pView->GetLineCount() - 1);
+			pView->SetCursorPos(ptPos1);
+			pView->SetAnchor(ptPos1);
 		}
 	}
 

--- a/Src/Plugins.cpp
+++ b/Src/Plugins.cpp
@@ -959,7 +959,7 @@ static void ShowPluginErrorMessage(IDispatch *piScript, LPTSTR description)
  */
 static HRESULT safeInvokeA(LPDISPATCH pi, VARIANT *ret, DISPID id, LPCCH op, ...)
 {
-	HRESULT h;
+	HRESULT h = E_FAIL;
 	SE_Handler seh;
 	TCHAR errorText[500];
 	bool bExceptionCatched = false;	
@@ -1012,7 +1012,7 @@ static HRESULT safeInvokeA(LPDISPATCH pi, VARIANT *ret, DISPID id, LPCCH op, ...
  */
 static HRESULT safeInvokeW(LPDISPATCH pi, VARIANT *ret, LPCOLESTR silent, LPCCH op, ...)
 {
-	HRESULT h;
+	HRESULT h = E_FAIL;
 	SE_Handler seh;
 	TCHAR errorText[500];
 	bool bExceptionCatched = false;

--- a/Src/SourceControl.cpp
+++ b/Src/SourceControl.cpp
@@ -385,8 +385,8 @@ void SourceControl::CheckinToClearCase(const String &strDestinationPath)
 	std::string vssPath = ucr::toUTF8(GetOptionsMgr()->GetString(OPT_VSS_PATH));
 	try
 	{
-		ProcessHandle hVss(Process::launch(vssPath, args));
-		int code = Process::wait(hVss);
+		ProcessHandle hVss1(Process::launch(vssPath, args));
+		int code = Process::wait(hVss1);
 		if (code != 0)
 		{
 			if (AppMsgBox::warning(_("Versioning System returned an error while attempting to check in the file.\n Please, check config spec of used view.\n Undo checkout operation?"),
@@ -397,8 +397,8 @@ void SourceControl::CheckinToClearCase(const String &strDestinationPath)
 				args.push_back("-rm");
 				format(sname_utf8, "\"%s\"", ucr::toUTF8(sname));
 				args.push_back(sname_utf8);
-				ProcessHandle hVss(Process::launch(vssPath, args));
-				code = Process::wait(hVss);
+				ProcessHandle hVss2(Process::launch(vssPath, args));
+				code = Process::wait(hVss2);
 				if (code != 0)
 				{
 					AppErrorMessageBox(_("Versioning System returned an error while attempting to undo checkout the file.\n Please, check config spec of used view. "));

--- a/Src/UniMarkdownFile.cpp
+++ b/Src/UniMarkdownFile.cpp
@@ -166,15 +166,15 @@ bool UniMarkdownFile::ReadString(String &line, String &eol, bool *lossy)
 			line = maketstring((const char *)current, m_current - current);
 			if (m_current < m_transparent)
 			{
-				unsigned char eol = *m_current++;
-				if (m_current < m_transparent && *m_current == (eol ^ ('\r'^'\n')))
+				unsigned char eol1 = *m_current++;
+				if (m_current < m_transparent && *m_current == (eol1 ^ ('\r'^'\n')))
 				{
 					++m_current;
 					++m_txtstats.ncrlfs;
 				}
 				else
 				{
-					++(eol == '\r' ? m_txtstats.ncrs : m_txtstats.nlfs);
+					++(eol1 == '\r' ? m_txtstats.ncrs : m_txtstats.nlfs);
 				}
 			}
 			bDone = true;
@@ -183,17 +183,17 @@ bool UniMarkdownFile::ReadString(String &line, String &eol, bool *lossy)
 		{
 			while (m_current < m_base + m_filesize && isspace(*m_current))
 			{
-				unsigned char eol = *m_current++;
-				if (eol == '\r' || eol == '\n')
+				unsigned char eol1 = *m_current++;
+				if (eol1 == '\r' || eol1 == '\n')
 				{
-					if (m_current < m_base + m_filesize && *m_current == (eol ^ ('\r'^'\n')))
+					if (m_current < m_base + m_filesize && *m_current == (eol1 ^ ('\r'^'\n')))
 					{
 						++m_current;
 						++m_txtstats.ncrlfs;
 					}
 					else
 					{
-						++(eol == '\r' ? m_txtstats.ncrs : m_txtstats.nlfs);
+						++(eol1 == '\r' ? m_txtstats.ncrs : m_txtstats.nlfs);
 					}
 				}
 			}

--- a/Src/diffutils/src/analyze.c
+++ b/Src/diffutils/src/analyze.c
@@ -979,9 +979,11 @@ struct change * diff_2_files (struct file_data filevec[], int depth, int * bin_s
 		//  Get the results of comparison in the form of a chain
 		// of `struct change's -- an edit script.  
 		
+#if 0
 		if (output_style == OUTPUT_ED)
 			script = build_reverse_script (filevec);
 		else
+#endif
 			script = build_script (filevec);
 		
 		//  Set CHANGES if we had any diffs.

--- a/Src/diffutils/src/diff.h
+++ b/Src/diffutils/src/diff.h
@@ -53,29 +53,34 @@ extern "C" {
 #endif
 
 enum output_style {
+	
+  // NOTE: these values are stored in the user's Registry - don't change their value !!
+  //   (see enum DiffOutputType in Src/CompareOptions.h)
   /* Default output style.  */
-  OUTPUT_NORMAL,
+  OUTPUT_NORMAL = 0,
   /* Output the differences with lines of context before and after (-c).  */
-  OUTPUT_CONTEXT,
+  OUTPUT_CONTEXT = 1,
   /* Output the differences in a unified context diff format (-u). */
-  OUTPUT_UNIFIED,
+  OUTPUT_UNIFIED = 2,
   /* Output the differences as commands suitable for `ed' (-e).  */
-  OUTPUT_ED,
+#if 0
+  OUTPUT_ED = 3,
   /* Output the diff as a forward ed script (-f).  */
-  OUTPUT_FORWARD_ED,
+  OUTPUT_FORWARD_ED = 4,
   /* Like -f, but output a count of changed lines in each "command" (-n). */
-  OUTPUT_RCS,
+  OUTPUT_RCS = 5,
   /* Output merged #ifdef'd file (-D).  */
-  OUTPUT_IFDEF,
+  OUTPUT_IFDEF = 6,
   /* Output sdiff style (-y).  */
-  OUTPUT_SDIFF,
+  OUTPUT_SDIFF = 7,
+#endif
   /* Output html style.  */
-  OUTPUT_HTML
+  OUTPUT_HTML = 8
 };
 
 /* True for output styles that are robust,
    i.e. can handle a file that ends in a non-newline.  */
-#define ROBUST_OUTPUT_STYLE(S) ((S) != OUTPUT_ED && (S) != OUTPUT_FORWARD_ED)
+#define ROBUST_OUTPUT_STYLE(S) ((S)>=0) // ((S) != OUTPUT_ED && (S) != OUTPUT_FORWARD_ED)
 
 EXTERN int output_style;
 

--- a/Src/dllpstub.cpp
+++ b/Src/dllpstub.cpp
@@ -127,13 +127,13 @@ HMODULE DLLPSTUB::Load()
 		if ((name = *proxy) != NULL)
 		{
 			DWORD dwError = ERROR_MOD_NOT_FOUND;
-			HMODULE handle = 0;
+			HMODULE handle1 = 0;
 			if (proxy[1] == name)
 			{
 				dwError = ERROR_PROC_NOT_FOUND;
-				handle = (HMODULE)proxy[2];
+				handle1 = (HMODULE)proxy[2];
 			}
-			Throw(name, handle, dwError, FALSE);
+			Throw(name, handle1, dwError, FALSE);
 		}
 	}
 	return handle;

--- a/Src/markdown.cpp
+++ b/Src/markdown.cpp
@@ -149,9 +149,9 @@ std::string CMarkdown::Resolve(const EntityMap &map, const std::string& v)
 		}
 		else
 		{
-			EntityMap::const_iterator p = map.find(key);
-			if (p != map.end())
-				value = p->second;
+			EntityMap::const_iterator p1 = map.find(key);
+			if (p1 != map.end())
+				value = p1->second;
 		}
 		*q = ';';
 		++q;

--- a/Testing/GoogleTest/BinaryCompare/BinaryCompare_test.cpp
+++ b/Testing/GoogleTest/BinaryCompare/BinaryCompare_test.cpp
@@ -129,12 +129,12 @@ namespace
 		files.SetLeft(_T("A"));
 		files.SetRight(_T("B"));
 		di.diffFileInfo[0].size = 1;
-		di.diffFileInfo[1].size = -1;
+		di.diffFileInfo[1].size = DirItem::FILE_SIZE_NONE;
 		EXPECT_EQ(DIFFCODE::DIFF, bc.CompareFiles(files, di));
 
 		files.SetLeft(_T("A"));
 		files.SetRight(_T("B"));
-		di.diffFileInfo[0].size = -1;
+		di.diffFileInfo[0].size = DirItem::FILE_SIZE_NONE;
 		di.diffFileInfo[1].size = 1;
 		EXPECT_EQ(DIFFCODE::DIFF, bc.CompareFiles(files, di));
 

--- a/Testing/GoogleTest/TimeSizeCompare/TimeSizeCompare_test.cpp
+++ b/Testing/GoogleTest/TimeSizeCompare/TimeSizeCompare_test.cpp
@@ -77,12 +77,12 @@ namespace
 		di.diffFileInfo[1].mtime = di.diffFileInfo[0].mtime + 10000000;
 		di.diffFileInfo[2].mtime = di.diffFileInfo[0].mtime + 20000000;
 
-		di.diffFileInfo[0].size = -1;
+		di.diffFileInfo[0].size = DirItem::FILE_SIZE_NONE;
 		di.diffFileInfo[1].size = 0;
 		EXPECT_EQ(DIFFCODE::DIFF, tsc.CompareFiles(CMP_SIZE, 2, di));
 	
 		di.diffFileInfo[0].size = 0;
-		di.diffFileInfo[1].size = -1;
+		di.diffFileInfo[1].size = DirItem::FILE_SIZE_NONE;
 		EXPECT_EQ(DIFFCODE::DIFF, tsc.CompareFiles(CMP_SIZE, 2, di));
 	
 		di.diffFileInfo[0].size = 1;

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2015.vcxproj
@@ -98,6 +98,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -124,6 +125,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -146,6 +148,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -171,6 +174,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
@@ -98,6 +98,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -124,6 +125,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -146,6 +148,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -171,6 +174,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION

I've set **warning level=4** for the WinMerge and UnitTests projects (but not typically for the three 'poco' projects).  This generates _**LOTS**_ of warnings; many categories are not interesting and I certainly do not recommend that the **Level=4** become an official setting.  But some warning categories do seem important, either functionally or aesthetically.   So, I'll slowly be working on the ones that I think are interesting.  Here is a first batch of commits ...

### Cleanup2: More Build security checking options

 * Add **SDLCheck=true** to all compilations for additional "Security Checking".  See [/sdl (Enable Additional Security Checks)](https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks)
 * Make sure that **BufferSecurityCheck=true**.  It had been set to **false** for the three 'poco' projects; the normal default value is **=true**.
 * Both VS2015 and VS2017 project files are changed.

### Cleanup2: Uninitialized Local Variables

 * L4 warning C4701: "potentially uninitialized local variable used".  This commit eliminates all occurrences from WinMerge and UnitTests projects (but not from the 'poco' projects).

### Cleanup2: Cleanup 'Output Style' declarations

 * Output Style values (selecting how to format patches that are generated by the `Tools|Generate Patch` menu dialog) were defined in two unrelated places (with slightly different names), but need to have the
identical values.
 * Furthermore, five of the eight values are not used by WinMerge.
 * And- the values may get stored into the Registry, so they cannot be accidentally changed in the future.

 * These changes simplify this situation by basing both definitions on the `diff.h` values, while leaving the two name groups both existing.
 * All declarations and references to the five unused values are commented-out

### Cleanup2: use named item for empty DirItem.size

 * Clarifies code and eliminates warning "C4245: conversion from `int `to `Poco::File::FileSize`, signed/unsigned mismatch"

### Cleanup2: C4456 "Decl hides previous local decl"

 * Remove a number of C4456 (level=4) warnings.  Declarations hiding previous local declarations is generally sloppy/dangerous practice.
 * and a few other minor cleanup changes

### Cleanup2: C4456 "Decl hides previous local decl" (continued)

 * Remove a number of C4456 (level=4) warnings.  Declarations hiding previous local declarations is generally sloppy/dangerous practice.
 * This commit now eliminates these warnings from WinMerge (but not from the 'poco' sub-projects).

