### PR TITLE
update to newest VS2017 Release 15.5

### DIFF
--- a/Externals/boost/boost/config/compiler/visualc.hpp
+++ b/Externals/boost/boost/config/compiler/visualc.hpp
@@ -317,7 +317,8 @@
 
 //
 // last known (but un-checked by Boost.org) version is 19.11.25506 (VS 2017 Update 3) - BillGord 15 Aug 2017
-#if (_MSC_VER > 1911)
+// VS2017 Version 15.5.0 (cl compiler version 19.12.25830.2) updated _MSC_VER to 1912 - BillGord 06 Dec 2017
+#if (_MSC_VER > 1912)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/Src/Merge.vs2015.vcxproj
+++ b/Src/Merge.vs2015.vcxproj
@@ -910,6 +910,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\Externals\boost\boost\config.hpp" />
+    <ClInclude Include="..\Externals\boost\boost\config\compiler\visualc.hpp" />
+    <ClInclude Include="..\Externals\boost\boost\config\select_compiler_config.hpp" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaleditview.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextbuffer.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.h" />

--- a/Src/Merge.vs2015.vcxproj.filters
+++ b/Src/Merge.vs2015.vcxproj.filters
@@ -47,6 +47,15 @@
     <Filter Include="MFCGui\Common">
       <UniqueIdentifier>{297182f0-e39d-4ac4-9df3-315882ce9e07}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Boost">
+      <UniqueIdentifier>{09e2ca67-f223-4fd6-b380-aca4a63886b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Boost\config">
+      <UniqueIdentifier>{6c139b98-08bf-4639-84f9-3848ad990352}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Boost\config\compiler">
+      <UniqueIdentifier>{48b82f25-08b5-43e5-bc19-abd5bf4f0ea7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -1421,6 +1430,15 @@
     </ClInclude>
     <ClInclude Include="..\Externals\crystaledit\editlib\ctextmarkerdlg.h">
       <Filter>EditLib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config.hpp">
+      <Filter>Boost</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config\compiler\visualc.hpp">
+      <Filter>Boost\config\compiler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config\select_compiler_config.hpp">
+      <Filter>Boost\config</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -910,6 +910,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\Externals\boost\boost\config.hpp" />
+    <ClInclude Include="..\Externals\boost\boost\config\compiler\visualc.hpp" />
+    <ClInclude Include="..\Externals\boost\boost\config\select_compiler_config.hpp" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaleditview.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextbuffer.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.h" />

--- a/Src/Merge.vs2017.vcxproj.filters
+++ b/Src/Merge.vs2017.vcxproj.filters
@@ -47,6 +47,15 @@
     <Filter Include="MFCGui\Common">
       <UniqueIdentifier>{297182f0-e39d-4ac4-9df3-315882ce9e07}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Boost">
+      <UniqueIdentifier>{09e2ca67-f223-4fd6-b380-aca4a63886b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Boost\config">
+      <UniqueIdentifier>{6c139b98-08bf-4639-84f9-3848ad990352}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Boost\config\compiler">
+      <UniqueIdentifier>{48b82f25-08b5-43e5-bc19-abd5bf4f0ea7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -1421,6 +1430,15 @@
     </ClInclude>
     <ClInclude Include="..\Externals\crystaledit\editlib\ctextmarkerdlg.h">
       <Filter>EditLib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config.hpp">
+      <Filter>Boost</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config\compiler\visualc.hpp">
+      <Filter>Boost\config\compiler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\boost\boost\config\select_compiler_config.hpp">
+      <Filter>Boost\config</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
+++ b/Testing/GoogleTest/UnitTests/UnitTests.vs2017.vcxproj
@@ -88,7 +88,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\Src;..\..\..\Src\Common;..\..\..\Externals\boost;..\..\..\Externals\poco\Foundation\include;..\..\..\Externals\poco\XML\include;..\..\..\Externals\gtest\include;..\..\..\Externals\gtest\;..\..\..\Src\diffutils\src;..\..\..\Src\diffutils\lib;..\..\..\Src\diffutils\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;UNICODE;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;UNICODE;POCO_STATIC;_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
@@ -115,7 +115,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\Src;..\..\..\Src\Common;..\..\..\Externals\boost;..\..\..\Externals\poco\Foundation\include;..\..\..\Externals\poco\XML\include;..\..\..\Externals\gtest\include;..\..\..\Externals\gtest\;..\..\..\Src\diffutils\src;..\..\..\Src\diffutils\lib;..\..\..\Src\diffutils\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_CONSOLE;UNICODE;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_CONSOLE;UNICODE;POCO_STATIC;_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
@@ -139,7 +139,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\Src;..\..\..\Src\Common;..\..\..\Externals\boost;..\..\..\Externals\poco\Foundation\include;..\..\..\Externals\poco\XML\include;..\..\..\Externals\gtest\include;..\..\..\Externals\gtest\;..\..\..\Src\diffutils\src;..\..\..\Src\diffutils\lib;..\..\..\Src\diffutils\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;UNICODE;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;UNICODE;POCO_STATIC;_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <PrecompiledHeader>
@@ -165,7 +165,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\Src;..\..\..\Src\Common;..\..\..\Externals\boost;..\..\..\Externals\poco\Foundation\include;..\..\..\Externals\poco\XML\include;..\..\..\Externals\gtest\include;..\..\..\Externals\gtest\;..\..\..\Src\diffutils\src;..\..\..\Src\diffutils\lib;..\..\..\Src\diffutils\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_CONSOLE;UNICODE;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_CONSOLE;UNICODE;POCO_STATIC;_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <PrecompiledHeader>

--- a/WinMerge.vs2017.sln
+++ b/WinMerge.vs2017.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Merge", "Src\Merge.vs2017.vcxproj", "{9FDA4AF0-CCFD-4812-BDB9-53EFEDB32BDE}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
### Three small commits to update to the newest VS2017 15.5 Release (November 2017)
* VS2017 - 15.5.0 kludge for GTest UnitTests
* Fix Boost's checking for new VS2017 Version 15.5.0
* VS2017 15.5.0 updated version in .sln file

## VS2017 - 15.5.0 kludge for GTest UnitTests

 * Using the latest (and just released) version 15.5.0 of **VS2017** introduces the following error (about 2400 times !) into the **UnitTests** project ...

> "error C4996: 'std::tr1': warning STL4002: The non-Standard std::tr1 namespace and TR1-only machinery are deprecated and will be REMOVED.  You can define **_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING** to acknowledge that you have received this warning. "

* MSDN claims that this is a C++17 language standards issue, but I was not able to solve this problem by specifying the use of the C++14 standard language (the Properties control for this is likewise a new
feature of version 15.5.0) 
	See...  [https://docs.microsoft.com/en-us/cpp/cpp-conformance-improvements-2017](https://docs.microsoft.com/en-us/cpp/cpp-conformance-improvements-2017)

* The only simple, short-term solution that I could come up with was to simply follow the suggestion of defining the `_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING` token as given above.

* Even though this problem has been discussed in the GoogleTest **GitHub** forum since at least 6 June, the underlying problem remains unresolved at this hour (well, by late 6 Dec anyway)...
	See... [https://github.com/google/googletest/issues/1111](https://github.com/google/googletest/issues/1111)
	See... [https://github.com/google/googletest/issues/1320](https://github.com/google/googletest/issues/1320)
	See... [https://github.com/google/googletest/pull/1311](https://github.com/google/googletest/pull/1311)

* I will assume that the **GoogleTest** resolution of this problem will require **WinMerge** to adopt the newest **GoogleTest** framework (which is likely a good idea anyway).  I will keep an eye on their progress and resolution and advise accordingly.  

* In the meantime, this kludge allows **WinMerge**'s **UnitTests** project to compile and execute correctly.


## Fix Boost's checking for new VS2017 Version 15.5.0

* Update 5 (dated Oct 2017) changes **_MSC_VER** to **1912**.  
	See... [https://blogs.msdn.microsoft.com/vcblog/2017/11/15/msvc-conformance-improvements-in-visual-studio-2017-version-15-5/](https://blogs.msdn.microsoft.com/vcblog/2017/11/15/msvc-conformance-improvements-in-visual-studio-2017-version-15-5/)

* This causes lots of compilation messages (neither Errors nor Warnings) with the text `Unknown compiler version - please run the configure tests and report the results`.   I have *not* reported this new issue to Boost.org (they will eventually catch up without my help)

* This tiny patch will prevent those compilation messages until a newer version of **Boost** becomes available and **WinMerge** chooses to adopt it.

* Since this has been a hard message to find twice now (previously with **VS2017 15.3.0**), I have added a new filter **Boost** to the Solution Explorer, containing a very small selection of boost configuration
files.  **Boost** itself is too large to include either completely, or even the reasonably small subset of boost files that **WinMerge** uses.

* Mimic changes also for **VS2015** to add the Boost filter to the Solution Explorer, even though this problem will never occur with **VS2015**

### VS2017 15.5.0 updated version in .sln file

* A simple auto-update of the  `WinMerge.vs2017.sln` file
