### PR TITLE
Old-style procedures and C++17 for more projects

### DIFF
--- a/Externals/poco/Foundation/Foundation.vs2017.vcxproj
+++ b/Externals/poco/Foundation/Foundation.vs2017.vcxproj
@@ -99,6 +99,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -129,6 +130,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -163,6 +165,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -197,6 +200,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Externals/poco/Foundation/include/Poco/DynamicFactory.h
+++ b/Externals/poco/Foundation/include/Poco/DynamicFactory.h
@@ -109,7 +109,7 @@ public:
 
 		FastMutex::ScopedLock lock(_mutex);
 
-		std::auto_ptr<AbstractFactory> ptr(pAbstractFactory);
+		std::unique_ptr<AbstractFactory> ptr(pAbstractFactory);
 		typename FactoryMap::iterator it = _map.find(className);
 		if (it == _map.end())
 			_map[className] = ptr.release();

--- a/Externals/poco/Util/Util.vs2017.vcxproj
+++ b/Externals/poco/Util/Util.vs2017.vcxproj
@@ -98,6 +98,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmtd.lib</OutputFile>
@@ -127,6 +128,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmtd.lib</OutputFile>
@@ -157,6 +159,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoUtilmt.lib</OutputFile>
@@ -187,6 +190,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoUtilmt.lib</OutputFile>

--- a/Externals/poco/XML/XML.vs2017.vcxproj
+++ b/Externals/poco/XML/XML.vs2017.vcxproj
@@ -98,6 +98,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmtd.lib</OutputFile>
@@ -127,6 +128,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmtd.lib</OutputFile>
@@ -156,6 +158,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoXMLmt.lib</OutputFile>
@@ -186,6 +189,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoXMLmt.lib</OutputFile>

--- a/ShellExtension/ShellExtension.vs2017.vcxproj
+++ b/ShellExtension/ShellExtension.vs2017.vcxproj
@@ -104,6 +104,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
@@ -143,6 +144,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
@@ -183,6 +185,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
@@ -222,6 +225,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
@@ -280,7 +284,6 @@
     </Midl>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="coretools.h" />
     <ClInclude Include="RegKey.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="StdAfx.h" />

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -318,6 +318,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -431,6 +432,7 @@
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Async</ExceptionHandling>
+      <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Src/diffutils/lib/cmpbuf.c
+++ b/Src/diffutils/lib/cmpbuf.c
@@ -21,8 +21,7 @@
 /* Least common multiple of two buffer sizes A and B.  */
 
 size_t
-buffer_lcm (a, b)
-     size_t a, b;
+buffer_lcm (size_t a, size_t b)
 {
   size_t m, n, r;
 

--- a/Src/diffutils/lib/cmpbuf.h
+++ b/Src/diffutils/lib/cmpbuf.h
@@ -23,7 +23,7 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 extern "C" {
 #endif
 
-size_t buffer_lcm PARAMS((size_t, size_t));
+size_t buffer_lcm (size_t, size_t);
 
 #ifdef __cplusplus
 }

--- a/Src/diffutils/src/ED.C
+++ b/Src/diffutils/src/ED.C
@@ -19,15 +19,14 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 #include "diff.h"
 
-static void print_ed_hunk PARAMS((struct change *));
-static void print_rcs_hunk PARAMS((struct change *));
-static void pr_forward_ed_hunk PARAMS((struct change *));
+static void print_ed_hunk (struct change *);
+static void print_rcs_hunk (struct change *);
+static void pr_forward_ed_hunk (struct change *);
 
 /* Print our script as ed commands.  */
 
 void
-print_ed_script (script)
-    struct change *script;
+print_ed_script (struct change *script)
 {
   print_script (script, find_reverse_change, print_ed_hunk);
 }
@@ -35,8 +34,7 @@ print_ed_script (script)
 /* Print a hunk of an ed diff */
 
 static void
-print_ed_hunk (hunk)
-     struct change *hunk; 
+print_ed_hunk (struct change *hunk)
 {
   int f0, l0, f1, l1;
   int deletes, inserts;
@@ -103,15 +101,13 @@ print_ed_hunk (hunk)
    which means that the commands are not truly useful with ed.  */
 
 void
-pr_forward_ed_script (script)
-     struct change *script;
+pr_forward_ed_script (struct change *script)
 {
   print_script (script, find_change, pr_forward_ed_hunk);
 }
 
 static void
-pr_forward_ed_hunk (hunk)
-     struct change *hunk;
+pr_forward_ed_hunk (struct change *hunk)
 {
   int i;
   int f0, l0, f1, l1;
@@ -147,8 +143,7 @@ pr_forward_ed_hunk (hunk)
    This format is used for RCS.  */
 
 void
-print_rcs_script (script)
-     struct change *script;
+print_rcs_script (struct change *script)
 {
   print_script (script, find_change, print_rcs_hunk);
 }
@@ -156,8 +151,7 @@ print_rcs_script (script)
 /* Print a hunk of an RCS diff */
 
 static void
-print_rcs_hunk (hunk)
-     struct change *hunk;
+print_rcs_hunk (struct change *hunk)
 {
   int i;
   int f0, l0, f1, l1;

--- a/Src/diffutils/src/NORMAL.C
+++ b/Src/diffutils/src/NORMAL.C
@@ -20,14 +20,13 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 #include "diff.h"
 
-static void print_normal_hunk PARAMS((struct change *));
+static void print_normal_hunk (struct change *);
 
 /* Print the edit-script SCRIPT as a normal diff.
    INF points to an array of descriptions of the two files.  */
 
 void
-print_normal_script (script)
-     struct change *script;
+print_normal_script (struct change *script)
 {
   print_script (script, find_change, print_normal_hunk);
 }
@@ -37,8 +36,7 @@ print_normal_script (script)
    describing changes in consecutive lines.  */
 
 static void
-print_normal_hunk (hunk)
-     struct change *hunk;
+print_normal_hunk (struct change *hunk)
 {
   int first0, last0, first1, last1, deletes, inserts;
   register int i;

--- a/Src/diffutils/src/analyze.c
+++ b/Src/diffutils/src/analyze.c
@@ -61,14 +61,14 @@ struct partition
   int hi_minimal;	/* Likewise for high half.  */
 };
 
-static int diag PARAMS((int, int, int, int, int, struct partition *));
-static struct change *add_change PARAMS((int, int, int, int, struct change *));
-static struct change *build_reverse_script PARAMS((struct file_data const[]));
-static struct change *build_script PARAMS((struct file_data const[]));
-static void briefly_report PARAMS((int, struct file_data const[]));
-static void compareseq PARAMS((int, int, int, int, int));
-static void discard_confusing_lines PARAMS((struct file_data[]));
-static void shift_boundaries PARAMS((struct file_data[]));
+static int diag (int, int, int, int, int, struct partition *);
+static struct change *add_change (int, int, int, int, struct change *);
+static struct change *build_reverse_script (struct file_data const[]);
+static struct change *build_script (struct file_data const[]);
+static void briefly_report (int, struct file_data const[]);
+static void compareseq (int, int, int, int, int);
+static void discard_confusing_lines (struct file_data[]);
+static void shift_boundaries (struct file_data[]);
 
 /* Find the midpoint of the shortest edit script for a specified
    portion of the two files.
@@ -102,9 +102,7 @@ static void shift_boundaries PARAMS((struct file_data[]));
    It cannot cause incorrect diff output.  */
 
 static int
-diag (xoff, xlim, yoff, ylim, minimal, part)
-     int xoff, xlim, yoff, ylim, minimal;
-     struct partition *part;
+diag (int xoff, int xlim, int yoff, int ylim, int minimal, struct partition *part)
 {
   int *const fd = fdiag;	/* Give the compiler a chance. */
   int *const bd = bdiag;	/* Additional help for the compiler. */
@@ -342,8 +340,7 @@ diag (xoff, xlim, yoff, ylim, minimal, part)
    expensive it is.  */
 
 static void
-compareseq (xoff, xlim, yoff, ylim, minimal)
-     int xoff, xlim, yoff, ylim, minimal;
+compareseq (int xoff, int xlim, int yoff, int ylim, int minimal)
 {
   int * const xv = xvec; /* Help the compiler.  */
   int * const yv = yvec;
@@ -731,9 +728,7 @@ shift_boundaries (struct file_data filevec[])
    which the insertion was done; vice versa for INSERTED and LINE1.  */
 
 static struct change *
-add_change (line0, line1, deleted, inserted, old)
-     int line0, line1, deleted, inserted;
-     struct change *old;
+add_change (int line0, int line1, int deleted, int inserted, struct change *old)
 {
   struct change *newob = (struct change *) xmalloc (sizeof (struct change));
   memset(newob, 0, sizeof(*newob));
@@ -752,8 +747,7 @@ add_change (line0, line1, deleted, inserted, old)
    producing an edit script in reverse order.  */
 
 static struct change *
-build_reverse_script (filevec)
-     struct file_data const filevec[];
+build_reverse_script (struct file_data const filevec[])
 {
   struct change *script = 0;
   char *changed0 = filevec[0].changed_flag;
@@ -790,8 +784,7 @@ build_reverse_script (filevec)
    producing an edit script in forward order.  */
 
 static struct change *
-build_script (filevec)
-     struct file_data const filevec[];
+build_script (struct file_data const filevec[])
 {
   struct change *script = 0;
   char *changed0 = filevec[0].changed_flag;
@@ -823,9 +816,7 @@ build_script (filevec)
 
 /* If CHANGES, briefly report that two files differed.  */
 static void
-briefly_report (changes, filevec)
-     int changes;
-     struct file_data const filevec[];
+briefly_report (int changes, struct file_data const filevec[])
 {
   if (changes)
     message (no_details_flag ? "Files %s and %s differ\n"

--- a/Src/diffutils/src/context.c
+++ b/Src/diffutils/src/context.c
@@ -19,14 +19,14 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 #include "diff.h"
 
-static struct change *find_hunk PARAMS((struct change *));
-static void find_function PARAMS((struct file_data const *, int, char const HUGE **, size_t *));
-static void mark_ignorable PARAMS((struct change *));
-static void pr_context_hunk PARAMS((struct change *));
-static void pr_unidiff_hunk PARAMS((struct change *));
-static void print_context_label PARAMS ((char const *, struct file_data *, char const *));
-static void print_context_number_range PARAMS((struct file_data const *, int, int));
-static void print_unidiff_number_range PARAMS((struct file_data const *, int, int));
+static struct change *find_hunk (struct change *);
+static void find_function (struct file_data const *, int, char const HUGE **, size_t *);
+static void mark_ignorable (struct change *);
+static void pr_context_hunk (struct change *);
+static void pr_unidiff_hunk (struct change *);
+static void print_context_label (char const *, struct file_data *, char const *);
+static void print_context_number_range (struct file_data const *, int, int);
+static void print_unidiff_number_range (struct file_data const *, int, int);
 
 /* Last place find_function started searching from.  */
 static DECL_TLS int find_function_last_search;
@@ -37,10 +37,7 @@ static DECL_TLS int find_function_last_match;
 /* Print a label for a context diff, with a file name and date or a label.  */
 
 static void
-print_context_label (mark, inf, label)
-     char const *mark;
-     struct file_data *inf;
-     char const *label;
+print_context_label(char const *mark, struct file_data *inf, char const *label)
 {
   if (label)
     fprintf (outfile, "%s %s\n", mark, label);
@@ -56,9 +53,7 @@ print_context_label (mark, inf, label)
 /* Print a header for a context diff, with the file names and dates.  */
 
 void
-print_context_header (inf, unidiff_flag)
-     struct file_data inf[];
-     int unidiff_flag;
+print_context_header(struct file_data inf[], int unidiff_flag)
 {
   if (unidiff_flag)
     {
@@ -75,9 +70,7 @@ print_context_header (inf, unidiff_flag)
 /* Print an edit script in context format.  */
 
 void
-print_context_script (script, unidiff_flag)
-     struct change *script;
-     int unidiff_flag;
+print_context_script (struct change *script, int unidiff_flag)
 {
   if (ignore_blank_lines_flag)
     mark_ignorable (script);
@@ -104,9 +97,7 @@ print_context_script (script, unidiff_flag)
    We print the translated (real) line numbers.  */
 
 static void
-print_context_number_range (file, a, b)
-     struct file_data const *file;
-     int a, b;
+print_context_number_range (struct file_data const *file, int a, int b)
 {
   int trans_a, trans_b;
   translate_range (file, a, b, &trans_a, &trans_b);
@@ -128,8 +119,7 @@ print_context_number_range (file, a, b)
    line with the appropriate flag-character.  */
 
 static void
-pr_context_hunk (hunk)
-     struct change *hunk;
+pr_context_hunk (struct change *hunk)
 {
   int first0, last0, first1, last1, show_from, show_to, i;
   struct change *next;
@@ -236,9 +226,7 @@ pr_context_hunk (hunk)
    We print the translated (real) line numbers.  */
 
 static void
-print_unidiff_number_range (file, a, b)
-     struct file_data const *file;
-     int a, b;
+print_unidiff_number_range (struct file_data const *file, int a, int b)
 {
   int trans_a, trans_b;
   translate_range (file, a, b, &trans_a, &trans_b);
@@ -260,8 +248,7 @@ print_unidiff_number_range (file, a, b)
    line with the appropriate flag-character.  */
 
 static void
-pr_unidiff_hunk (hunk)
-     struct change *hunk;
+pr_unidiff_hunk (struct change *hunk)
 {
   int first0, last0, first1, last1, show_from, show_to, i, j, k;
   struct change *next;
@@ -357,8 +344,7 @@ pr_unidiff_hunk (hunk)
    to the `struct change' for the last change before those lines.  */
 
 static struct change *
-find_hunk (start)
-     struct change *start;
+find_hunk (struct change *start)
 {
   struct change *prev;
   int top0, top1;
@@ -393,8 +379,7 @@ find_hunk (start)
    are ignorable lines.  */
 
 static void
-mark_ignorable (script)
-     struct change *script;
+mark_ignorable (struct change *script)
 {
   while (script)
     {

--- a/Src/diffutils/src/diff.h
+++ b/Src/diffutils/src/diff.h
@@ -311,68 +311,68 @@ EXTERN FILE *outfile;
 
 /* analyze.c */
 /* WinMerge: add last two params */
-struct change * diff_2_files PARAMS((struct file_data[], int, int *, int, int*));
+struct change * diff_2_files (struct file_data[], int, int *, int, int*);
 void moved_block_analysis(struct change ** pscript, struct file_data fd[]);
 
 /* context.c */
-void print_context_header PARAMS((struct file_data[], int));
-void print_context_script PARAMS((struct change *, int));
+void print_context_header (struct file_data[], int);
+void print_context_script (struct change *, int);
 
 /* diff.c */
-int excluded_filename PARAMS((char const *));
+int excluded_filename (char const *);
 
 /* dir.c */
 //int diff_dirs (CDiffContext*);
 
 /* ed.c */
-void print_ed_script PARAMS((struct change *));
-void pr_forward_ed_script PARAMS((struct change *));
+void print_ed_script (struct change *);
+void pr_forward_ed_script (struct change *);
 
 /* ifdef.c */
-void print_ifdef_script PARAMS((struct change *));
+void print_ifdef_script (struct change *);
 
 /* io.c */
 /* WinMerge: add last pointer param */
-int read_files PARAMS((struct file_data[], int, int *));
-int sip PARAMS((struct file_data *, int));
-void slurp PARAMS((struct file_data *));
+int read_files (struct file_data[], int, int *);
+int sip (struct file_data *, int);
+void slurp (struct file_data *);
 
 /* normal.c */
-void print_normal_script PARAMS((struct change *));
+void print_normal_script (struct change *);
 
 /* rcs.c */
-void print_rcs_script PARAMS((struct change *));
+void print_rcs_script (struct change *);
 
 /* side.c */
-void print_sdiff_script PARAMS((struct change *));
+void print_sdiff_script (struct change *);
 
 /* util.c */
-void *xmalloc PARAMS((size_t));
-void *xrealloc PARAMS((void *, size_t));
-char *concat PARAMS((char const *, char const *, char const *));
-char *dir_file_pathname PARAMS((char const *, char const *));
-int change_letter PARAMS((int, int));
-int line_cmp PARAMS((char const HUGE *, size_t, char const HUGE *, size_t));
-int translate_line_number PARAMS((struct file_data const *, int));
-struct change *find_change PARAMS((struct change *));
-struct change *find_reverse_change PARAMS((struct change *));
-void analyze_hunk PARAMS((struct change *, int *, int *, int *, int *, int *, int *, const struct file_data fd[]));
-void begin_output PARAMS((void));
-void debug_script PARAMS((struct change *));
-void error PARAMS((char const *, char const *, char const *));
-void fatal PARAMS((char const *));
-void finish_output PARAMS((void));
-void message PARAMS((char const *, char const *, char const *));
-void message5 PARAMS((char const *, char const *, char const *, char const *, char const *));
-void output_1_line PARAMS((char const HUGE *, char const HUGE *, char const *, char const *));
-void perror_with_name PARAMS((char const *));
-void pfatal_with_name PARAMS((char const *));
-void print_1_line PARAMS((char const *, char const HUGE * const *));
-void print_message_queue PARAMS((void));
-void print_number_range PARAMS((int, struct file_data *, int, int));
-void print_script PARAMS((struct change *, struct change * (*) PARAMS((struct change *)), void (*) PARAMS((struct change *))));
-void setup_output PARAMS((char const *, char const *, int));
-void translate_range PARAMS((struct file_data const *, int, int, int *, int *));
+void *xmalloc (size_t);
+void *xrealloc (void *, size_t);
+char *concat (char const *, char const *, char const *);
+char *dir_file_pathname (char const *, char const *);
+int change_letter (int, int);
+int line_cmp (char const HUGE *, size_t, char const HUGE *, size_t);
+int translate_line_number (struct file_data const *, int);
+struct change *find_change (struct change *);
+struct change *find_reverse_change (struct change *);
+void analyze_hunk (struct change *, int *, int *, int *, int *, int *, int *, const struct file_data fd[]);
+void begin_output (void);
+void debug_script (struct change *);
+void error (char const *, char const *, char const *);
+void fatal (char const *);
+void finish_output (void);
+void message (char const *, char const *, char const *);
+void message5 (char const *, char const *, char const *, char const *, char const *);
+void output_1_line (char const HUGE *, char const HUGE *, char const *, char const *);
+void perror_with_name (char const *);
+void pfatal_with_name (char const *);
+void print_1_line (char const *, char const HUGE * const *);
+void print_message_queue (void);
+void print_number_range (int, struct file_data *, int, int);
+void print_script (struct change *, struct change * (*) (struct change *), void (*) (struct change *));
+void setup_output (char const *, char const *, int);
+void translate_range (struct file_data const *, int, int, int *, int *);
 void cleanup_file_buffers(struct file_data fd[]);
 int FileIsBinary(int fd);
 

--- a/Src/diffutils/src/ifdef.c
+++ b/Src/diffutils/src/ifdef.c
@@ -28,21 +28,20 @@ struct group
   int from, upto; /* start and limit lines for this group of lines */
 };
 
-static char *format_group PARAMS((FILE *, char *, int, struct group const[]));
-static char *scan_char_literal PARAMS((char *, int *));
-static char *scan_printf_spec PARAMS((char *));
-static int groups_letter_value PARAMS((struct group const[], int));
-static void format_ifdef PARAMS((char *, int, int, int, int));
-static void print_ifdef_hunk PARAMS((struct change *));
-static void print_ifdef_lines PARAMS((FILE *, char *, struct group const *));
+static char *format_group (FILE *, char *, int, struct group const[]);
+static char *scan_char_literal (char *, int *);
+static char *scan_printf_spec (char *);
+static int groups_letter_value (struct group const[], int);
+static void format_ifdef (char *, int, int, int, int);
+static void print_ifdef_hunk (struct change *);
+static void print_ifdef_lines (FILE *, char *, struct group const *);
 
 static DECL_TLS int next_line;
 
 /* Print the edit-script SCRIPT as a merged #ifdef file.  */
 
 void
-print_ifdef_script (script)
-     struct change *script;
+print_ifdef_script (struct change *script)
 {
   next_line = - files[0].prefix_lines;
   print_script (script, find_change, print_ifdef_hunk);
@@ -60,8 +59,7 @@ print_ifdef_script (script)
    describing changes in consecutive lines.  */
 
 static void
-print_ifdef_hunk (hunk)
-     struct change *hunk;
+print_ifdef_hunk (struct change *hunk)
 {
   int first0, last0, first1, last1, deletes, inserts;
   char *format;
@@ -92,9 +90,7 @@ print_ifdef_hunk (hunk)
    lines BEG1 up to END1 are from the second file.  */
 
 static void
-format_ifdef (format, beg0, end0, beg1, end1)
-     char *format;
-     int beg0, end0, beg1, end1;
+format_ifdef (char *format, int beg0, int end0, int beg1, int end1)
 {
   struct group groups[2];
 
@@ -114,11 +110,7 @@ format_ifdef (format, beg0, end0, beg1, end1)
    If OUT is zero, do not actually print anything; just scan the format.  */
 
 static char *
-format_group (out, format, endchar, groups)
-     register FILE *out;
-     char *format;
-     int endchar;
-     struct group const groups[];
+format_group (register FILE *out, char *format, int endchar, struct group const groups[])
 {
   register char c;
   register char *f = format;
@@ -238,9 +230,7 @@ format_group (out, format, endchar, groups)
 /* For the line group pair G, return the number corresponding to LETTER.
    Return -1 if LETTER is not a group format letter.  */
 static int
-groups_letter_value (g, letter)
-     struct group const g[];
-     int letter;
+groups_letter_value (struct group const g[], int letter)
 {
   if (isupper (letter))
     {
@@ -261,10 +251,7 @@ groups_letter_value (g, letter)
 /* Print to file OUT, using FORMAT to print the line group GROUP.
    But do nothing if OUT is zero.  */
 static void
-print_ifdef_lines (out, format, group)
-     register FILE *out;
-     char *format;
-     struct group const *group;
+print_ifdef_lines (register FILE *out, char *format, struct group const *group)
 {
   struct file_data const *file = group->file;
   char const HUGE * const *linbuf = file->linbuf;
@@ -365,9 +352,7 @@ print_ifdef_lines (out, format, group)
    Yield the address of the first character after the closing apostrophe,
    or zero if the literal is ill-formed.  */
 static char *
-scan_char_literal (lit, intptr)
-     char *lit;
-     int *intptr;
+scan_char_literal (char *lit, int *intptr)
 {
   register char *p = lit;
   int value, digits;
@@ -407,8 +392,7 @@ scan_char_literal (lit, intptr)
 /* Scan optional printf-style SPEC of the form `-*[0-9]*(.[0-9]*)?[cdoxX]'.
    Return the address of the character following SPEC, or zero if failure.  */
 static char *
-scan_printf_spec (spec)
-     register char *spec;
+scan_printf_spec (register char *spec)
 {
   register unsigned char c;
 

--- a/Src/diffutils/src/io.c
+++ b/Src/diffutils/src/io.c
@@ -18,9 +18,7 @@ along with GNU DIFF; see the file COPYING.  If not, write to
 the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 #include "diff.h"
-#ifdef _WIN32
-#  include <io.h>
-#endif
+#include <io.h>
 #include <cassert>
 
 /* Rotate a value n bits to the left. */
@@ -77,9 +75,9 @@ static DECL_TLS int equivs_index;
 /* Number of elements allocated in the array `equivs'.  */
 static DECL_TLS int equivs_alloc;
 
-static void find_and_hash_each_line PARAMS((struct file_data *));
-static void find_identical_ends PARAMS((struct file_data[]));
-static char *prepare_text_end PARAMS((struct file_data *, short));
+static void find_and_hash_each_line (struct file_data *);
+static void find_identical_ends (struct file_data[]);
+static char *prepare_text_end (struct file_data *, short);
 static enum UNICODESET get_unicode_signature(struct file_data *, unsigned *bom);
 
 /* Check for binary files and compare them for exact identity.  */
@@ -139,9 +137,7 @@ static enum UNICODESET get_unicode_signature(struct file_data *current, unsigned
    and if it appears to be a binary file.  */
 
 int
-sip (current, skip_test)
-     struct file_data *current;
-     int skip_test;
+sip (struct file_data *current, int skip_test)
 {
   int isbinary = 0;
   /* If we have a nonexistent file (or NUL: device) at this stage, treat it as empty.  */
@@ -184,8 +180,7 @@ sip (current, skip_test)
 /* Slurp the rest of the current file completely into memory.  */
 
 void
-slurp (current)
-     struct file_data *current;
+slurp (struct file_data *current)
 {
   size_t cc;
 
@@ -262,8 +257,7 @@ ISWSPACE (char ch)
 /* Split the file into lines, simultaneously computing the equivalence class for
    each line. */
 static void
-find_and_hash_each_line (current)
-     struct file_data *current;
+find_and_hash_each_line (struct file_data *current)
 {
   unsigned h;
   unsigned char const HUGE *p = (unsigned char const HUGE *) current->prefix_end;
@@ -479,9 +473,7 @@ hashing_done:;
    Return effective start of text to be compared. */
 
 static char *
-prepare_text_end (current, side)
-     struct file_data *current;
-	 short side;
+prepare_text_end (struct file_data *current, short side)
 {
   FSIZE buffered_chars = current->buffered_chars;
   char *const p = current->buffer;
@@ -710,8 +702,7 @@ prepare_text_end (current, side)
    prefixes and suffixes of each object. */
 
 static void
-find_identical_ends (filevec)
-     struct file_data filevec[];
+find_identical_ends (struct file_data filevec[])
 {
   word HUGE *w0, HUGE *w1;
   char HUGE *p0, HUGE *p1, HUGE *buffer0, HUGE *buffer1;
@@ -991,10 +982,7 @@ static int const primes[] =
    If bin_file is given, then check both files for binary files,
    otherwise check second file only if first wasn't binary */
 int
-read_files (filevec, pretend_binary, bin_file)
-     struct file_data filevec[];
-     int pretend_binary;
-     int * bin_file;
+read_files (struct file_data filevec[], int pretend_binary, int *bin_file)
 {
   int i;
   int skip_test = always_text_flag | pretend_binary;

--- a/Src/diffutils/src/side.c
+++ b/Src/diffutils/src/side.c
@@ -21,11 +21,11 @@ and this notice must be preserved on all copies.  */
 
 #include "diff.h"
 
-static unsigned print_half_line PARAMS((char const HUGE * const *, unsigned, unsigned));
-static unsigned tab_from_to PARAMS((unsigned, unsigned));
-static void print_1sdiff_line PARAMS((char const HUGE * const *, int, char const HUGE * const *));
-static void print_sdiff_common_lines PARAMS((int, int));
-static void print_sdiff_hunk PARAMS((struct change *));
+static unsigned print_half_line (char const * const *, unsigned, unsigned);
+static unsigned tab_from_to (unsigned, unsigned);
+static void print_1sdiff_line (char const * const *, int, char const * const *);
+static void print_sdiff_common_lines (int, int);
+static void print_sdiff_hunk (struct change *);
 
 /* Next line number to be printed in the two input files.  */
 static DECL_TLS int next0, next1;
@@ -33,8 +33,7 @@ static DECL_TLS int next0, next1;
 /* Print the edit-script SCRIPT as a sdiff style output.  */
 
 void
-print_sdiff_script (script)
-     struct change *script;
+print_sdiff_script (struct change *script)
 {
   begin_output ();
 
@@ -47,8 +46,7 @@ print_sdiff_script (script)
 /* Tab from column FROM to column TO, where FROM <= TO.  Yield TO.  */
 
 static unsigned
-tab_from_to (from, to)
-     unsigned from, to;
+tab_from_to (unsigned from, unsigned to)
 {
   FILE *out = outfile;
   unsigned tab;
@@ -70,9 +68,7 @@ tab_from_to (from, to)
  * written (not the number of chars).
  */
 static unsigned
-print_half_line (line, indent, out_bound)
-     char const HUGE * const *line;
-     unsigned indent, out_bound;
+print_half_line (char const * const *line, unsigned indent, unsigned out_bound)
 {
   FILE *out = outfile;
   register unsigned in_position = 0, out_position = 0;
@@ -165,10 +161,7 @@ print_half_line (line, indent, out_bound)
  */
 
 static void
-print_1sdiff_line (left, sep, right)
-     char const HUGE * const *left;
-     int sep;
-     char const HUGE * const *right;
+print_1sdiff_line (char const HUGE * const *left, int sep, char const HUGE * const *right)
 {
   FILE *out = outfile;
   unsigned hw = sdiff_half_width, c2o = sdiff_column2_offset;
@@ -207,8 +200,7 @@ print_1sdiff_line (left, sep, right)
 
 /* Print lines common to both files in side-by-side format.  */
 static void
-print_sdiff_common_lines (limit0, limit1)
-     int limit0, limit1;
+print_sdiff_common_lines (int limit0, int limit1)
 {
   int i0 = next0, i1 = next1;
 
@@ -237,8 +229,7 @@ print_sdiff_common_lines (limit0, limit1)
    describing changes in consecutive lines.  */
 
 static void
-print_sdiff_hunk (hunk)
-     struct change *hunk;
+print_sdiff_hunk (struct change *hunk)
 {
   int first0, last0, first1, last1, deletes, inserts;
   register int i, j;

--- a/Src/diffutils/src/system.h
+++ b/Src/diffutils/src/system.h
@@ -31,13 +31,6 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if __STDC__ || defined(__MSDOS__) || defined(__NT__) || defined(WIN32) || defined(WIN64)
-#define PARAMS(args) args
-#else
-#define PARAMS(args) ()
-#define void char
-#endif
-
 #if STAT_MACROS_BROKEN
 #undef S_ISBLK
 #undef S_ISCHR

--- a/Src/diffutils/src/util.c
+++ b/Src/diffutils/src/util.c
@@ -45,8 +45,7 @@ static struct msg **msg_chain_end = &msg_chain;
    TEXT should normally be the file name.  */
 
 void
-perror_with_name (text)
-     char const *text;
+perror_with_name (char const *text)
 {
   int e = errno;
   fprintf (stderr, "%s: ", program);
@@ -57,8 +56,7 @@ perror_with_name (text)
 /* Use when a system call returns non-zero status and that is fatal.  */
 
 void
-pfatal_with_name (text)
-     char const *text;
+pfatal_with_name (char const *text)
 {
   int e = errno;
   print_message_queue ();
@@ -73,8 +71,7 @@ pfatal_with_name (text)
    with args ARG1 and ARG2.  */
 
 void
-error (format, arg, arg1)
-     char const *format, *arg, *arg1;
+error (char const *format, char const *arg, char const *arg1)
 {
   fprintf (stderr, "%s: ", program);
   fprintf (stderr, format, arg, arg1);
@@ -84,8 +81,7 @@ error (format, arg, arg1)
 /* Print an error message containing the string TEXT, then exit.  */
 
 void
-fatal (m)
-     char const *m;
+fatal (char const *m)
 {
   print_message_queue ();
   error ("%s", m, 0);
@@ -97,15 +93,13 @@ fatal (m)
    This is used for things like "binary files differ" and "Only in ...".  */
 
 void
-message (format, arg1, arg2)
-     char const *format, *arg1, *arg2;
+message (char const *format, char const *arg1, char const *arg2)
 {
   message5 (format, arg1, arg2, 0, 0);
 }
 
 void
-message5 (format, arg1, arg2, arg3, arg4)
-     char const *format, *arg1, *arg2, *arg3, *arg4;
+message5 (char const *format, char const *arg1, char const *arg2, char const *arg3, char const *arg4)
 {
   if (paginate_flag)
     {
@@ -150,9 +144,7 @@ static char const *current_name1;
 static int current_depth;
 
 void
-setup_output (name0, name1, depth)
-     char const *name0, *name1;
-     int depth;
+setup_output (char const *name0, char const *name1, int depth)
 {
   current_name0 = name0;
   current_name1 = name1;
@@ -304,9 +296,7 @@ ISWSPACE (char ch)
    Return 1 if the lines differ, like `memcmp'.  */
 
 int
-line_cmp (s1, len1, s2, len2)
-     char const HUGE *s1, HUGE *s2;
-     size_t len1, len2;
+line_cmp (char const *s1, size_t len1, char const *s2, size_t len2)
 {
   register unsigned char const *t1, *t2;
   register unsigned char end_char = line_end_char;
@@ -495,15 +485,13 @@ line_cmp (s1, len1, s2, len2)
    Return the last link before the first gap.  */
 
 struct change *
-find_change (start)
-     struct change *start;
+find_change (struct change *start)
 {
   return start;
 }
 
 struct change *
-find_reverse_change (start)
-     struct change *start;
+find_reverse_change (struct change *start)
 {
   return start;
 }
@@ -520,10 +508,9 @@ find_reverse_change (start)
    link at the end) and prints it.  */
 
 void
-print_script (script, hunkfun, printfun)
-     struct change *script;
-     struct change * (*hunkfun) PARAMS((struct change *));
-     void (*printfun) PARAMS((struct change *));
+print_script (struct change *script, 
+				struct change *(*hunkfun) (struct change *), 
+				void (*printfun) (struct change *) )
 {
   struct change *next = script;
 
@@ -556,9 +543,7 @@ print_script (script, hunkfun, printfun)
    the line is inserted, deleted, changed, etc.).  */
 
 void
-print_1_line (line_flag, line)
-     char const *line_flag;
-     char const HUGE * const *line;
+print_1_line (char const *line_flag, char const * const *line)
 {
   char const HUGE *text = line[0], HUGE *limit = line[1]; /* Help the compiler.  */
   FILE *out = outfile; /* Help the compiler some more.  */
@@ -650,8 +635,7 @@ fwrite_textify( const void *buffer, size_t size, size_t count, FILE *stream )
    internal carriage return, so that tab stops continue to line up.  */
 
 void
-output_1_line (text, limit, flag_format, line_flag)
-     char const HUGE *text, HUGE *limit, *flag_format, *line_flag;
+output_1_line (char const *text, char const *limit, char const *flag_format, char const *line_flag)
 {
   char * pos = NULL;
   if (!tab_expand_flag)
@@ -700,8 +684,7 @@ output_1_line (text, limit, flag_format, line_flag)
 }
 
 int
-change_letter (inserts, deletes)
-     int inserts, deletes;
+change_letter (int inserts, int deletes)
 {
   if (!inserts)
     return 'd';
@@ -719,18 +702,13 @@ change_letter (inserts, deletes)
    Actual line numbers count from 1 within the entire file.  */
 
 int
-translate_line_number (file, lnum)
-     struct file_data const *file;
-     int lnum;
+translate_line_number (struct file_data const *file, int lnum)
 {
   return lnum + file->prefix_lines + 1;
 }
 
 void
-translate_range (file, a, b, aptr, bptr)
-     struct file_data const *file;
-     int a, b;
-     int *aptr, *bptr;
+translate_range (struct file_data const *file, int a, int b, int *aptr, int *bptr)
 {
   *aptr = translate_line_number (file, a - 1) + 1;
   *bptr = translate_line_number (file, b + 1) - 1;
@@ -743,10 +721,7 @@ translate_range (file, a, b, aptr, bptr)
    We print the translated (real) line numbers.  */
 
 void
-print_number_range (sepchar, file, a, b)
-     int sepchar;
-     struct file_data *file;
-     int a, b;
+print_number_range (int sepchar, struct file_data *file, int a, int b)
 {
   int trans_a, trans_b;
   translate_range (file, a, b, &trans_a, &trans_b);
@@ -779,11 +754,7 @@ int iseolch (char ch)
    set to 0.  */
 
 void
-analyze_hunk (hunk, first0, last0, first1, last1, deletes, inserts, fd)
-     struct change *hunk;
-     int *first0, *last0, *first1, *last1;
-     int *deletes, *inserts;
-     const struct file_data fd[];
+analyze_hunk (struct change *hunk, int *first0, int *last0, int *first1, int *last1, int *deletes, int *inserts, const struct file_data fd[])
 {
   int l0, l1, show_from, show_to;
   int i;
@@ -841,8 +812,7 @@ analyze_hunk (hunk, first0, last0, first1, last1, deletes, inserts, fd)
 /* malloc a block of memory, with fatal error message if we can't do it. */
 
 VOID *
-xmalloc (size)
-     size_t size;
+xmalloc (size_t size)
 {
   register VOID *value;
 
@@ -863,9 +833,7 @@ xmalloc (size)
 /* realloc a block of memory, with fatal error message if we can't do it. */
 
 VOID *
-xrealloc (old, size)
-     VOID *old;
-     size_t size;
+xrealloc (VOID *old, size_t size)
 {
   register VOID *value;
 
@@ -886,8 +854,7 @@ xrealloc (old, size)
 /* Concatenate three strings, returning a newly malloc'd string.  */
 
 char *
-concat (s1, s2, s3)
-     char const *s1, *s2, *s3;
+concat (char const *s1, char const *s2, char const *s3)
 {
   size_t len = strlen (s1) + strlen (s2) + strlen (s3);
   char *new = xmalloc (len + 1);
@@ -899,8 +866,7 @@ concat (s1, s2, s3)
    of the file in DIR whose filename is FILE.  */
 
 char *
-dir_file_pathname (dir, file)
-     char const *dir, *file;
+dir_file_pathname (char const *dir, char const *file)
 {
 #if defined(__MSDOS__) || defined(__NT__) || defined(WIN32)
   char sep = dir[strlen(dir) - 1];
@@ -911,8 +877,7 @@ dir_file_pathname (dir, file)
 }
 
 void
-debug_script (sp)
-     struct change *sp;
+debug_script (struct change *sp)
 {
   fflush (stdout);
   for (; sp; sp = sp->link)


### PR DESCRIPTION
## Two (unrelated) commits ...

### Eliminate old-style procedure declarators

 * Old-style procedure declarators appeared as ...
	`myFunc (a, b, c)`
	`   int a, c; char * b;`
	`{ ... }`
 * This style is very-very old **C** language.
 * In modern C and C++, this procedure would be declared as ...
	`myFunc (int a, char * b, int c);`
       `{ ... }`

 * This eliminates level-4 warning C4131: "uses old-style declarator"
 * Eliminate the awkward `PARAMS()` macro, which was used to simulate the
new style on old compilers that lacked the new style.

 * These patches only effect the DiffEngine

### Compile Merge sub-projects with **C++17** language rules.

 * Force the **ShellExtensions**, and the various **Poco** sub-projects
to be compiled with **C++17** language semantics when using  **VS2017**.
 * Use `unique_ptr<>` to replace `auto_ptr<>`
 * Compile **Merge** with **C++17** when using the **Test** configuration.

 * (unrelated) `coretools.h` is not used by **ShellExtensions**

### Note ...
* **WinMerge** continues to compile and run correctly with **VS2015**.
