### PR TITLE
Eliminate worst of Level=4 compilation warnings

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -1723,7 +1723,7 @@ OnUpdateEditUndo (CCmdUI * pCmdUI)
           //  Format menu item text using the provided item description
           CString desc;
           m_pTextBuffer->GetUndoDescription (desc);
-          menu.Format (IDS_MENU_UNDO_FORMAT, desc);
+          menu.Format (IDS_MENU_UNDO_FORMAT, (LPCTSTR)desc);
         }
       else
         {
@@ -1815,7 +1815,7 @@ OnUpdateEditRedo (CCmdUI * pCmdUI)
           //  Format menu item text using the provided item description
           CString desc;
           m_pTextBuffer->GetRedoDescription (desc);
-          menu.Format (IDS_MENU_REDO_FORMAT, desc);
+          menu.Format (IDS_MENU_REDO_FORMAT, (LPCTSTR)desc);
         }
       else
         {

--- a/Externals/crystaledit/editlib/ccrystaltextmarkers.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextmarkers.cpp
@@ -85,7 +85,7 @@ CString CCrystalTextMarkers::Serialize() const
 		if (marker.second.bUserDefined)
 		{
 			text.AppendFormat(_T("%s:%s\t%d\t%d\t%d\t%d\n"),
-				marker.first, marker.second.sFindWhat, 
+				(LPCTSTR)marker.first, (LPCTSTR)marker.second.sFindWhat, 
 				marker.second.dwFlags, marker.second.nBgColorIndex,
 				marker.second.bUserDefined, marker.second.bVisible);
 		}

--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -5361,7 +5361,7 @@ OnEditRepeat ()
             (m_dwLastSearchFlags & FIND_NO_WRAP) == 0, &ptFoundPos))
         {
           CString prompt;
-          prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), sText);
+          prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), (LPCTSTR)sText);
           AfxMessageBox (prompt, MB_ICONINFORMATION);
           return;
         }
@@ -6372,7 +6372,7 @@ void CCrystalTextView::OnUpdateStatusMessage( CStatusBar *pStatusBar )
     formatid = IDS_FIND_INCREMENTAL_BACKWARD;
   else
     return;
-  strFormat.Format( LoadResString(formatid).c_str(), *m_pstrIncrementalSearchString );
+  strFormat.Format( LoadResString(formatid).c_str(), (LPCTSTR)*m_pstrIncrementalSearchString );
 
   pStatusBar->SetPaneText( 0, strFormat );
   bUpdatedAtLastCall = false;

--- a/Externals/crystaledit/editlib/ceditreplacedlg.cpp
+++ b/Externals/crystaledit/editlib/ceditreplacedlg.cpp
@@ -211,7 +211,7 @@ DoHighlightText ( bool bNotifyIfNotFound )
       if ( bNotifyIfNotFound ) 
       {
         CString prompt;
-        prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), m_sText);
+        prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), (LPCTSTR)m_sText);
         AfxMessageBox (prompt, MB_ICONINFORMATION);
       }
       if (m_nScope == 0)
@@ -251,7 +251,7 @@ DoReplaceText (LPCTSTR /*pszNewText*/, DWORD dwSearchFlags)
   if (!bFound)
     {
       CString prompt;
-      prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), m_sText);
+      prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), (LPCTSTR)m_sText);
       AfxMessageBox (prompt, MB_ICONINFORMATION);
       if (m_nScope == 0)
         m_ptCurrentPos = m_ptBlockBegin;

--- a/Externals/crystaledit/editlib/cfindtextdlg.cpp
+++ b/Externals/crystaledit/editlib/cfindtextdlg.cpp
@@ -99,7 +99,7 @@ FindText (int nDirection)
       if (!m_pBuddy->FindText(GetLastSearchInfos()))
         {
           CString prompt;
-          prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), m_sText);
+          prompt.Format (LoadResString(IDS_EDIT_TEXT_NOT_FOUND).c_str(), (LPCTSTR)m_sText);
           AfxMessageBox (prompt, MB_ICONINFORMATION);
         }
       else

--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -524,8 +524,8 @@ bool DirItemEnumerator::MultiStepCompressArchive(LPCTSTR path)
 		bool bDone = MultiStepCompressArchive(pathIntermediate);
 		if (bDone)
 		{
-			piHandler->CompressArchive(hwndOwner, path,
-				&SingleItemEnumerator(path, pathIntermediate));
+			SingleItemEnumerator tmpEnumerator(path, pathIntermediate);
+			piHandler->CompressArchive(hwndOwner, path, &tmpEnumerator);
 			DeleteFile(pathIntermediate);
 		}
 		else

--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -624,7 +624,8 @@ DecompressResult DecompressArchive(HWND hWnd, const PathContext& files)
 		USES_CONVERSION;
 		// Handle archives using 7-zip
 		Merge7z::Format *piHandler;
-		if (piHandler = ArchiveGuessFormat(res.files[0]))
+		piHandler = ArchiveGuessFormat(res.files[0]);
+		if (piHandler)
 		{
 			res.pTempPathContext = new CTempPathContext;
 			path = env::GetTempChildPath();
@@ -645,10 +646,13 @@ DecompressResult DecompressArchive(HWND hWnd, const PathContext& files)
 				SysFreeString(pTmp);
 				res.files[0].insert(0, _T("\\"));
 				res.files[0].insert(0, path);
-			} while (piHandler = ArchiveGuessFormat(res.files[0]));
+				piHandler = ArchiveGuessFormat(res.files[0]);
+			} while (piHandler);
 			res.files[0] = path;
 		}
-		if (!res.files[1].empty() && (piHandler = ArchiveGuessFormat(res.files[1])))
+		piHandler = res.files[1].empty() ? nullptr
+										 : ArchiveGuessFormat(res.files[1]);
+		if (piHandler)
 		{
 			if (!res.pTempPathContext)
 			{
@@ -670,10 +674,12 @@ DecompressResult DecompressArchive(HWND hWnd, const PathContext& files)
 				SysFreeString(pTmp);
 				res.files[1].insert(0, _T("\\"));
 				res.files[1].insert(0, path);
-			} while (piHandler = ArchiveGuessFormat(res.files[1]));
+				piHandler = ArchiveGuessFormat(res.files[1]);
+			} while (piHandler);
 			res.files[1] = path;
 		}
-		if (res.files.GetSize() > 2 && (piHandler = ArchiveGuessFormat(res.files[2])))
+		piHandler = (res.files.GetSize() <= 2) ? nullptr : ArchiveGuessFormat(res.files[2]);
+		if (piHandler)
 		{
 			if (!res.pTempPathContext)
 			{
@@ -695,7 +701,8 @@ DecompressResult DecompressArchive(HWND hWnd, const PathContext& files)
 				SysFreeString(pTmp);
 				res.files[2].insert(0, _T("\\"));
 				res.files[2].insert(0, path);
-			} while (piHandler = ArchiveGuessFormat(res.files[2]));
+				piHandler = ArchiveGuessFormat(res.files[2]);
+			} while (piHandler);
 			res.files[2] = path;
 		}
 		if (res.files[1].empty())

--- a/Src/Common/BCMenu.cpp
+++ b/Src/Common/BCMenu.cpp
@@ -399,7 +399,8 @@ void BCMenu::DrawItem_Win9xNT2000 (LPDRAWITEMSTRUCT lpDIS)
 			}
 			else{
 				if(state&ODS_CHECKED){
-					pDC->FillRect(rect2,&CBrush(LightenColor(clrBack,0.6)));
+					CBrush cbTemp = LightenColor(clrBack, 0.6);
+					pDC->FillRect(rect2,&cbTemp);
 					rect2.SetRect(rect.left,rect.top+dy,rect.left+m_iconX+4,
                         rect.top+m_iconY+4+dy);
 					pDC->Draw3dRect(rect2,GetSysColor(COLOR_3DSHADOW),
@@ -1668,7 +1669,8 @@ void BCMenu::GetTransparentBitmap(CBitmap &bmp)
 	col=RGB(255,0,255); // Original was RGB(192,192,192)
 	CBitmap * pddcOldBmp2 = ddc2.SelectObject(&bmp2);
 	CRect rect(0,0,BitMap.bmWidth,BitMap.bmHeight);
-	ddc2.FillRect(rect,&CBrush(col));
+	CBrush cbTemp = col;
+	ddc2.FillRect(rect, &cbTemp);
 	ddc2.SelectObject(pddcOldBmp2);
 	newcol=GetSysColor(COLOR_3DFACE);
 
@@ -1708,7 +1710,8 @@ void BCMenu::GetDisabledBitmap(CBitmap &bmp,COLORREF background)
 	bmp2.CreateCompatibleBitmap(&ddc,BitMap.bmWidth,BitMap.bmHeight);
 	CBitmap * pddcOldBmp2 = ddc2.SelectObject(&bmp2);
 	CRect rect(0,0,BitMap.bmWidth,BitMap.bmHeight);
-	ddc2.FillRect(rect,&CBrush(GetSysColor(COLOR_3DFACE)));
+	CBrush cbTemp = GetSysColor(COLOR_3DFACE);
+	ddc2.FillRect(rect, &cbTemp);
 	ddc2.SelectObject(pddcOldBmp2);
 	discol=GetSysColor(COLOR_BTNSHADOW);
 
@@ -1793,7 +1796,8 @@ BOOL BCMenu::Draw3DCheckmark(CDC *dc, const CRect& rc,
 	CRect rcDest = rc;
 	COLORREF col=GetSysColor(COLOR_MENU);
 	if(!bSelected)col = LightenColor(col,0.6);
-	dc->FillRect(rcDest,&CBrush(col));
+	CBrush cbTemp = col;
+	dc->FillRect(rcDest, &cbTemp);
 	dc->DrawEdge(&rcDest, BDR_SUNKENOUTER, BF_RECT);
 	if (!hbmCheck)DrawCheckMark(dc,rc.left+4,rc.top+4,GetSysColor(COLOR_MENUTEXT));
 	else DrawRadioDot(dc,rc.left+5,rc.top+4,GetSysColor(COLOR_MENUTEXT));

--- a/Src/Common/LanguageSelect.cpp
+++ b/Src/Common/LanguageSelect.cpp
@@ -1041,10 +1041,9 @@ std::vector<std::pair<LANGID, String> > CLanguageSelect::GetAvailableLanguages()
 	HANDLE h = INVALID_HANDLE_VALUE;
 	do
 	{
-		LangFileInfo &lfi =
-			h == INVALID_HANDLE_VALUE
-		?	LangFileInfo(wSourceLangId)
-		:	LangFileInfo(paths::ConcatPath(path, ff.cFileName).c_str());
+		LangFileInfo lfi(wSourceLangId);
+		if (h != INVALID_HANDLE_VALUE)
+			lfi = LangFileInfo(paths::ConcatPath(path, ff.cFileName).c_str());
 		String str;
 		str += lfi.GetString(LOCALE_SLANGUAGE);
 		str += _T(" - ");

--- a/Src/Common/PreferencesDlg.cpp
+++ b/Src/Common/PreferencesDlg.cpp
@@ -241,8 +241,12 @@ CString CPreferencesDlg::GetItemPath(HTREEITEM hti)
 {
 	CString sPath = m_tcPages.GetItemText(hti);
 
-	while (hti = m_tcPages.GetParentItem(hti))
+	hti = m_tcPages.GetParentItem(hti);
+	while (hti)
+	{
 		sPath = m_tcPages.GetItemText(hti) + _T(" > ") + sPath;
+		hti = m_tcPages.GetParentItem(hti);
+	}
 
 	return sPath;
 }

--- a/Src/DDXHelper.h
+++ b/Src/DDXHelper.h
@@ -2,24 +2,6 @@
 
 #include "UnicodeString.h"
 
-// from http://stackoverflow.com/questions/6117270/mfc-stdstring-vs-cstring
-class PopString : public CString
-{
-public:
-	explicit PopString(String & final) : CString(final.c_str()), m_final(final)
-	{
-	}
-
-	~PopString()
-	{
-		m_final = (PCTSTR) *this;
-	}
-private:
-	PopString(const PopString &);  // private copy constructor to prevent copying
-	PopString & operator=(const PopString &);  // private copy operator
-
-	String & m_final;
-};
 
 inline void DDX_Check(CDataExchange* pDX, int nIDC, bool& value)
 {
@@ -37,16 +19,22 @@ inline void DDX_Radio(CDataExchange* pDX, int nIDC, bool& value)
 
 inline void DDX_Text(CDataExchange* pDX, int nIDC, String& value)
 {
-	DDX_Text(pDX, nIDC, PopString(value));
+	CString cstrValue = value.c_str();
+	DDX_Text(pDX, nIDC, cstrValue);
+	value = cstrValue;
 }
 
 inline void DDX_CBString(CDataExchange* pDX, int nIDC, String& value)
 {
-	DDX_CBString(pDX, nIDC, PopString(value));
+	CString cstrValue = value.c_str();
+	DDX_CBString(pDX, nIDC, cstrValue);
+	value = cstrValue;
 }
 
 inline void DDX_CBStringExact(CDataExchange* pDX, int nIDC, String& value)
 {
-	DDX_CBStringExact(pDX, nIDC, PopString(value));
+	CString cstrValue = value.c_str();
+	DDX_CBStringExact(pDX, nIDC, cstrValue);
+	value = cstrValue;
 }
 

--- a/Src/DirCmpReportDlg.cpp
+++ b/Src/DirCmpReportDlg.cpp
@@ -117,7 +117,9 @@ BOOL DirCmpReportDlg::OnInitDialog()
 
 	// Set selected path to variable so file selection dialog shows
 	// correct filename and path.
-	m_ctlReportFile.GetWindowText(PopString(m_sReportFile));
+	CString cstrReportFile;
+	m_ctlReportFile.GetWindowText(cstrReportFile);
+	m_sReportFile = cstrReportFile;
 
 	UpdateData(FALSE);
 

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1657,7 +1657,8 @@ void CDirView::DoOpen(SIDE_TYPE stype)
 {
 	int sel = GetSingleSelectedItem();
 	if (sel == -1) return;
-	String file = GetSelectedFileName(SelBegin(), stype, GetDiffContext());
+	DirItemIterator dirBegin = SelBegin();
+	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
 	if (file.empty()) return;
 	HINSTANCE rtn = ShellExecute(::GetDesktopWindow(), _T("edit"), file.c_str(), 0, 0, SW_SHOWNORMAL);
 	if (reinterpret_cast<uintptr_t>(rtn) == SE_ERR_NOASSOC)
@@ -1671,7 +1672,8 @@ void CDirView::DoOpenWith(SIDE_TYPE stype)
 {
 	int sel = GetSingleSelectedItem();
 	if (sel == -1) return;
-	String file = GetSelectedFileName(SelBegin(), stype, GetDiffContext());
+	DirItemIterator dirBegin = SelBegin();
+	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
 	if (file.empty()) return;
 	CString sysdir;
 	if (!GetSystemDirectory(sysdir.GetBuffer(MAX_PATH), MAX_PATH)) return;
@@ -1685,7 +1687,8 @@ void CDirView::DoOpenWithEditor(SIDE_TYPE stype)
 {
 	int sel = GetSingleSelectedItem();
 	if (sel == -1) return;
-	String file = GetSelectedFileName(SelBegin(), stype, GetDiffContext());
+	DirItemIterator dirBegin = SelBegin();
+	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
 	if (file.empty()) return;
 
 	theApp.OpenFileToExternalEditor(file);
@@ -1695,7 +1698,8 @@ void CDirView::DoOpenParentFolder(SIDE_TYPE stype)
 {
 	int sel = GetSingleSelectedItem();
 	if (sel == -1) return;
-	String file = GetSelectedFileName(SelBegin(), stype, GetDiffContext());
+	DirItemIterator dirBegin = SelBegin();
+	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
 	if (file.empty()) return;
 	String parentFolder = paths::GetParentPath(file);
 	ShellExecute(::GetDesktopWindow(), _T("open"), parentFolder.c_str(), 0, 0, SW_SHOWNORMAL);
@@ -3060,7 +3064,8 @@ afx_msg void CDirView::OnEndLabelEdit(NMHDR* pNMHDR, LRESULT* pResult)
 		if (!sText.IsEmpty())
 		{
 			try {
-				*pResult = DoItemRename(SelBegin(), GetDiffContext(), String(sText));
+				DirItemIterator dirBegin = SelBegin();
+				*pResult = DoItemRename(dirBegin, GetDiffContext(), String(sText));
 			} catch (ContentsChangedException& e) {
 				AfxMessageBox(e.m_msg.c_str(), MB_ICONWARNING);
 			}

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1114,19 +1114,22 @@ bool CImgMergeFrame::PromptAndSaveIfNeeded(bool bAllowCancel)
 	{
 		if (bLModified && dlg.m_leftSave == SaveClosingDlg::SAVECLOSING_SAVE)
 		{
-			if (!(bLSaveSuccess = DoFileSave(0)))
+			bLSaveSuccess = DoFileSave(0);
+			if (!bLSaveSuccess)
 				result = false;
 		}
 
 		if (bMModified && dlg.m_middleSave == SaveClosingDlg::SAVECLOSING_SAVE)
 		{
-			if (!(bMSaveSuccess = DoFileSave(1)))
+			bMSaveSuccess = DoFileSave(1);
+			if (!bMSaveSuccess)
 				result = false;
 		}
 
 		if (bRModified && dlg.m_rightSave == SaveClosingDlg::SAVECLOSING_SAVE)
 		{
-			if (!(bRSaveSuccess = DoFileSave(m_pImgMergeWindow->GetPaneCount() - 1)))
+			bRSaveSuccess = DoFileSave(m_pImgMergeWindow->GetPaneCount() - 1);
+			if (!bRSaveSuccess)
 				result = false;
 		}
 	}

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -2300,8 +2300,8 @@ BOOL CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[0].empty()) ? strDesc[0] : _("Theirs File"),
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
 			DWORD dwFlags[2] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
-			conflictCompared = DoFileOpen(&PathContext(revFile, workFile), 
-						dwFlags, strDesc2);
+			PathContext tmpPathContext(revFile, workFile);
+			conflictCompared = DoFileOpen(&tmpPathContext, dwFlags, strDesc2);
 		}
 		else
 		{
@@ -2309,9 +2309,9 @@ BOOL CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[0].empty()) ? strDesc[0] : _("Base File"),
 				(strDesc && !strDesc[1].empty()) ? strDesc[1] : _("Theirs File"),
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
+			PathContext tmpPathContext(baseFile, revFile, workFile);
 			DWORD dwFlags[3] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
-			conflictCompared = DoFileOpen(&PathContext(baseFile, revFile, workFile), 
-						dwFlags, strDesc3);
+			conflictCompared = DoFileOpen(&tmpPathContext, dwFlags, strDesc3);
 		}
 	}
 	else

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -3177,8 +3177,7 @@ bool CMergeDoc::GenerateReport(const String& sFileName) const
 
 	file.SetCodepage(ucr::CP_UTF_8);
 
-	String header = 
-		strutils::format(
+	CString headerText =
 		_T("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n")
 		_T("\t\"http://www.w3.org/TR/html4/loose.dtd\">\n")
 		_T("<html>\n")
@@ -3200,8 +3199,9 @@ bool CMergeDoc::GenerateReport(const String& sFileName) const
 		_T("<div class=\"border\">")
 		_T("<table cellspacing=\"0\" cellpadding=\"0\" style=\"width: 100%%; margin: 0; border: none;\">\n")
 		_T("<thead>\n")
-		_T("<tr>\n"),
-		nFontSize, m_pView[0]->GetHTMLStyles());
+		_T("<tr>\n");
+	String header = 
+		strutils::format((LPCTSTR)headerText, nFontSize, (LPCTSTR)m_pView[0]->GetHTMLStyles());
 	file.WriteString(header);
 
 	// Get paths

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3263,7 +3263,7 @@ void CMergeEditView::OnEditCopyLineNumbers()
 		CString sSpaces(' ', static_cast<int>(nNumWidth - strutils::to_str(line + 1).length()));
 		
 		strText += sSpaces;
-		strNumLine.Format(_T("%d: %s"), line + 1, strLine);
+		strNumLine.Format(_T("%d: %s"), line + 1, (LPCTSTR)strLine);
 		strText += strNumLine;
  	}
 	PutToClipboard(strText, strText.GetLength(), m_bColumnSelection);

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -524,9 +524,11 @@ void COpenView::OnOK()
 	if (GetOptionsMgr()->GetBool(OPT_CLOSE_WITH_OK))
 		GetParentFrame()->PostMessage(WM_CLOSE);
 
+	PathContext tmpPathContext(pDoc->m_files);
+	PackingInfo tmpPackingInfo(pDoc->m_infoHandler);
 	GetMainFrame()->DoFileOpen(
-		&PathContext(pDoc->m_files), std::array<DWORD, 3>(pDoc->m_dwFlags).data(), 
-		NULL, _T(""), !!pDoc->m_bRecurse, NULL, _T(""), &PackingInfo(pDoc->m_infoHandler));
+		&tmpPathContext, std::array<DWORD, 3>(pDoc->m_dwFlags).data(), 
+		NULL, _T(""), !!pDoc->m_bRecurse, NULL, _T(""), &tmpPackingInfo);
 }
 
 /** 

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -744,8 +744,10 @@ void COpenView::OnSelchangeCombo(int index)
 	int sel = m_ctlPath[index].GetCurSel();
 	if (sel != CB_ERR)
 	{
-		m_ctlPath[index].GetLBText(sel, PopString(m_strPath[index]));
-		m_ctlPath[index].SetWindowText(m_strPath[index].c_str());
+		CString cstrPath;
+		m_ctlPath[index].GetLBText(sel, cstrPath);
+		m_strPath[index] = cstrPath;
+		m_ctlPath[index].SetWindowText(cstrPath);
 		UpdateData(TRUE);
 	}
 	UpdateButtonStates();

--- a/Src/PatchDlg.cpp
+++ b/Src/PatchDlg.cpp
@@ -173,9 +173,9 @@ void CPatchDlg::OnOK()
 	int contextSel = m_comboContext.GetCurSel();
 	if (contextSel != CB_ERR)
 	{
-		String contextText;
-		m_comboContext.GetLBText(contextSel, PopString(contextText));
-		m_contextLines = std::stoi(contextText);
+		CString contextText;
+		m_comboContext.GetLBText(contextSel, contextText);
+		m_contextLines = std::stoi((String)contextText);
 	}
 	else
 		m_contextLines = 0;
@@ -349,8 +349,10 @@ void CPatchDlg::OnSelchangeFile1Combo()
 	int sel = m_ctlFile1.GetCurSel();
 	if (sel != CB_ERR)
 	{
-		m_ctlFile1.GetLBText(sel, PopString(m_file1));
-		m_ctlFile1.SetWindowText(m_file1.c_str());
+		CString cstrFile1 = m_file1.c_str();
+		m_ctlFile1.GetLBText(sel, cstrFile1);
+		m_ctlFile1.SetWindowText(cstrFile1);
+		m_file1 = cstrFile1;
 		ChangeFile(m_file1, true);
 	}
 }
@@ -363,8 +365,10 @@ void CPatchDlg::OnSelchangeFile2Combo()
 	int sel = m_ctlFile2.GetCurSel();
 	if (sel != CB_ERR)
 	{
-		m_ctlFile2.GetLBText(sel, PopString(m_file2));
-		m_ctlFile2.SetWindowText(m_file2.c_str());
+		CString cstrFile2 = m_file1.c_str();
+		m_ctlFile1.GetLBText(sel, cstrFile2);
+		m_ctlFile1.SetWindowText(cstrFile2);
+		m_file2 = cstrFile2;
 		ChangeFile(m_file2, false);
 	}
 }
@@ -377,8 +381,10 @@ void CPatchDlg::OnSelchangeResultCombo()
 	int sel = m_ctlResult.GetCurSel();
 	if (sel != CB_ERR)
 	{
-		m_ctlResult.GetLBText(sel, PopString(m_fileResult));
-		m_ctlResult.SetWindowText(m_fileResult.c_str());
+		CString cstrFileResult = m_fileResult.c_str();
+		m_ctlResult.GetLBText(sel, cstrFileResult);
+		m_ctlResult.SetWindowText(cstrFileResult);
+		m_fileResult = cstrFileResult;
 	}
 }
 
@@ -415,11 +421,13 @@ void CPatchDlg::OnDiffSwapFiles()
 {
 	PATCHFILES files;
 
-	m_ctlFile1.GetWindowText(PopString(m_file1));
-	m_ctlFile2.GetWindowText(PopString(m_file2));
+	CString cstrFile1 = m_file1.c_str();
+	CString cstrFile2 = m_file2.c_str();
+	m_ctlFile1.GetWindowText(cstrFile1);
+	m_ctlFile2.GetWindowText(cstrFile2);
 
-	m_ctlFile1.SetWindowText(m_file2.c_str());
-	m_ctlFile2.SetWindowText(m_file1.c_str());
+	m_ctlFile1.SetWindowText(cstrFile2);
+	m_ctlFile2.SetWindowText(cstrFile1);
 
 	//  swapped files
 	Swap();

--- a/Src/SelectUnpackerDlg.cpp
+++ b/Src/SelectUnpackerDlg.cpp
@@ -259,7 +259,9 @@ void CSelectUnpackerDlg::OnSelchangeUnpackerName()
 		// initialize with the default unpacker
 		m_pPlugin = static_cast<PluginInfo*> (m_UnpackerPlugins.GetAt(0));
 		PluginInfo * pPlugin;
-		m_cboUnpackerName.GetWindowText(PopString(m_strPluginName));
+		CString cstrPluginName;
+		m_cboUnpackerName.GetWindowText(cstrPluginName);
+		m_strPluginName = cstrPluginName;
 		for (int j = 0 ; j < m_UnpackerPlugins.GetSize() ; j++)
 		{
 			pPlugin = static_cast<PluginInfo*> (m_UnpackerPlugins.GetAt(j));

--- a/Src/TempFile.cpp
+++ b/Src/TempFile.cpp
@@ -181,7 +181,8 @@ static bool CleanupWMtempfolder(const vector <int>& processIDs)
 				if (!WMrunning(processIDs, pid))
 				{
 					tempfolderPID = paths::ConcatPath(paths::GetParentPath(pattern), ff.cFileName); 
-					if (res = ClearTempfolder(tempfolderPID))
+					res = ClearTempfolder(tempfolderPID);
+					if (res)
 						bok = !!FindNextFile(h, &ff) ;
 					continue;
 				}

--- a/Src/TrDialogs.h
+++ b/Src/TrDialogs.h
@@ -23,7 +23,10 @@ public:
 
 	unsigned GetDlgItemText(unsigned id, String& text)
 	{
-		return dlg()->GetDlgItemTextW(id, PopString(text));
+		CString cstrText = text.c_str();
+		unsigned uResult = dlg()->GetDlgItemTextW(id, cstrText);
+		text = cstrText;
+		return uResult;
 	}
 
 	void SetDlgItemText(unsigned id, const String& text)


### PR DESCRIPTION
These five commits remove various compilation warnings that occur at **Level=4**.  All deal with exploiting "_non-standard but tolerated_" **VC** compiler constructs.  There are hundreds of additional Level=4 warnings, but most are not interesting enough to eliminate.  

Notes ...
* I did not look for **Level=4** issues in the three **Poco** sub-projects.

* All projects continue to be compiled at **Level=3**, and generate no warning messages.

* I think I am finished with the removal of "important" compilation issues detected by **Level=4**.

 ### Remove warning C4239: nonstandard extension used

 * Eliminate warnings such as ...
	`warning C4239: nonstandard extension used: 'argument': conversion from 'item' to 'item&'`
	`note: A non-const reference may only be bound to an lvalue`

 * This commit only deals with issues with mixing `CString `and `String `data.
 * Discard the PopString class, a self-admitted hack from [stackoverflow.com](http://stackoverflow.com/questions/6117270/mfc-stdstring-vs-cstring), that was simply confusing and not all that "pretty" anyway.

###  Remove warning C4239 (2)

 * Eliminate warnings such as ...
	`warning C4239: nonstandard extension used: 'initializing': conversion from 'item' to 'item&'`
	`note: A non-const reference may only be bound to an lvalue`
 * And more warnings such as ...
	`warning C4239: nonstandard extension used: 'argument': conversion from 'item' to 'item&'`
	`note: A non-const reference may only be bound to an lvalue`

 ### Remove warning C4238: nonstandard extension used

 * Eliminate warnings such as ...
      `warning C4238: nonstandard extension used: class rvalue used as lvalue`

### Remove warning C4840: non-portable use of class ...

 * Sample of the 5-line warning message ...

     `warning C4840: non-portable use of class 'ATL::CStringT<wchar_t, StrTraitMFC<wchar_t, `
      ` ..... ATL::ChTraitsCRT<wchar_t>>>' as an argument to a variadic function`
     `note: 'ATL::CStringT<wchar_t, StrTraitMFC<wchar_t, ATL::ChTraitsCRT<wchar_t>>>::CStringT'`
     `..... is non-trivial` 	
     `note: see declaration of 'ATL::CStringT<wchar_t, StrTraitMFC<wchar_t,`
     `..... ATL::ChTraitsCRT<wchar_t>>>::CStringT' (compiling source file MergeEditView.cpp)`
     `note: the constructor and destructor will not be called; a bitwise copy of the class will be`
     `..... passed as the argument`
     `note: see declaration of 'ATL::CStringT<wchar_t, StrTraitMFC<wchar_t,  `
     `..... ATL::ChTraitsCRT<wchar_t>>>' (compiling source file MergeEditView.cpp)`

### Remove warning C4706: assignment in conditional

 * Remove all instances of the warning ...
      `warning C4706: assignment within conditional expression`