### PR TITLE
Improve reading of files > 2GB (1)

### DIFF
--- a/Src/diffutils/src/io.c
+++ b/Src/diffutils/src/io.c
@@ -224,10 +224,12 @@ slurp (struct file_data *current)
               current->buffer = xrealloc (current->buffer, current->bufsize);
 #endif /*__MSDOS__*/
             }
-		  assert((current->bufsize - current->buffered_chars) < UINT_MAX);
+          unsigned int bytes_to_read = min((unsigned int)(current->bufsize - current->buffered_chars), INT_MAX);
+          if (bytes_to_read == 0)
+            break;
           cc = _read (current->desc,
-          current->buffer + current->buffered_chars,
-          (unsigned int)(current->bufsize - current->buffered_chars));
+                      current->buffer + current->buffered_chars,
+                      bytes_to_read);
           if (cc == 0)
             break;
           if (cc == -1)
@@ -908,7 +910,6 @@ find_identical_ends (struct file_data filevec[])
 
   /* Allocate line buffer 1.  */
   tem = prefix_count ? filevec[1].suffix_begin - buffer1 : n1;
-  assert((filevec[1].prefix_end - buffer1) < INT_MAX);
   ttt = (int)(filevec[1].prefix_end - buffer1);
   alloc_lines1
     = (buffered_prefix


### PR DESCRIPTION
 Now that commit 4e4e46c81427ca34e940b511c31af732ed184e3c has allowed files larger than 2GB (for 64-bit builds), there are a number of places in **WinMerge** that are not prepared to handle files that large.  These will  have to be discovered by carefully focused "trial and error".  These are the first two (of many) problems encountered ...

* This patch repairs two places that `assert`with long file sizes.
* It should be noted that Windows can only read/write in chunks of up to 2GB.  The code around lines 227 to 232 is part of a loop that is capable of reading very large files in sequential 2GB chunks.  It now has the correct setup code to limit the size of each successive read. 
* The `assert` at line 911 is completely unnecessary for both 32- and 64-bit builds.

For further information regarding **files > 2GB**, see [issue #91](https://bitbucket.org/winmerge/winmerge/issues/91/problems-with-files-2gb) in the [Winmerge repo](https://bitbucket.org/winmerge/winmerge/overview) at BitBucket