### PR TITLE
Attempt to fix the issue #100 - Part 2 ... and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,19 @@
 **/Debug
 
 *.exe
+*.dll
 *.pdb
 *.bak
 *.VC.db
 *.VC.VC.opendb
+*.vcxproj.user
+*.ilk
+*.aps
+*.tlb
 
 Testing/Data/ShellFileOpTest/File1.txt
 Translations/WinMerge/MergeLang.rc
 /ShellExtension/dlldata.c
 /ShellExtension/ShellExtension.h
+/ShellExtension/ShellExtension_i.c
+/ShellExtension/ShellExtension_p.c

--- a/Src/Merge.vs2015.vcxproj
+++ b/Src/Merge.vs2015.vcxproj
@@ -941,6 +941,7 @@
     <ClInclude Include="..\Externals\crystaledit\editlib\UndoRecord.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ViewableWhitespace.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\wispelld.h" />
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h" />
     <ClInclude Include="..\Version.h" />
     <ClInclude Include="7zCommon.h" />
     <ClInclude Include="AboutDlg.h" />

--- a/Src/Merge.vs2015.vcxproj.filters
+++ b/Src/Merge.vs2015.vcxproj.filters
@@ -56,6 +56,9 @@
     <Filter Include="GNU diffutils">
       <UniqueIdentifier>{16e1af2b-75c9-4deb-b49f-819018df0478}</UniqueIdentifier>
     </Filter>
+    <Filter Include="MergeTest">
+      <UniqueIdentifier>{63f0497b-0d8f-4660-b727-dac620d74635}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -748,12 +751,6 @@
     <ClCompile Include="MergeStatusBar.cpp">
       <Filter>MFCGui\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Test.cpp">
-      <Filter>MFCGui\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="TestMain.cpp">
-      <Filter>MFCGui\Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="diffutils\src\mystat.cpp">
       <Filter>GNU diffutils</Filter>
     </ClCompile>
@@ -780,6 +777,12 @@
     </ClCompile>
     <ClCompile Include="CompareEngines\Wrap_DiffUtils.cpp">
       <Filter>Compare Engines</Filter>
+    </ClCompile>
+    <ClCompile Include="Test.cpp">
+      <Filter>MergeTest</Filter>
+    </ClCompile>
+    <ClCompile Include="TestMain.cpp">
+      <Filter>MergeTest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1410,9 +1413,6 @@
     <ClInclude Include="MergeStatusBar.h">
       <Filter>MFCGui\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="TestMain.h">
-      <Filter>MFCGui\Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.h">
       <Filter>EditLib</Filter>
     </ClInclude>
@@ -1442,6 +1442,12 @@
     </ClInclude>
     <ClInclude Include="CompareEngines\Wrap_DiffUtils.h">
       <Filter>Compare Engines</Filter>
+    </ClInclude>
+    <ClInclude Include="TestMain.h">
+      <Filter>MergeTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>MergeTest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -948,6 +948,7 @@
     <ClInclude Include="..\Externals\crystaledit\editlib\UndoRecord.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ViewableWhitespace.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\wispelld.h" />
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h" />
     <ClInclude Include="..\Version.h" />
     <ClInclude Include="7zCommon.h" />
     <ClInclude Include="AboutDlg.h" />

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{9FDA4AF0-CCFD-4812-BDB9-53EFEDB32BDE}</ProjectGuid>
     <RootNamespace>Merge</RootNamespace>
     <Keyword>MFCProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'" Label="Configuration">

--- a/Src/Merge.vs2017.vcxproj.filters
+++ b/Src/Merge.vs2017.vcxproj.filters
@@ -56,6 +56,9 @@
     <Filter Include="GNU diffutils">
       <UniqueIdentifier>{16e1af2b-75c9-4deb-b49f-819018df0478}</UniqueIdentifier>
     </Filter>
+    <Filter Include="MergeTest">
+      <UniqueIdentifier>{63f0497b-0d8f-4660-b727-dac620d74635}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -748,12 +751,6 @@
     <ClCompile Include="MergeStatusBar.cpp">
       <Filter>MFCGui\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Test.cpp">
-      <Filter>MFCGui\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="TestMain.cpp">
-      <Filter>MFCGui\Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="diffutils\src\mystat.cpp">
       <Filter>GNU diffutils</Filter>
     </ClCompile>
@@ -780,6 +777,12 @@
     </ClCompile>
     <ClCompile Include="CompareEngines\Wrap_DiffUtils.cpp">
       <Filter>Compare Engines</Filter>
+    </ClCompile>
+    <ClCompile Include="Test.cpp">
+      <Filter>MergeTest</Filter>
+    </ClCompile>
+    <ClCompile Include="TestMain.cpp">
+      <Filter>MergeTest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1410,9 +1413,6 @@
     <ClInclude Include="MergeStatusBar.h">
       <Filter>MFCGui\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="TestMain.h">
-      <Filter>MFCGui\Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\Externals\crystaledit\editlib\ccrystaltextmarkers.h">
       <Filter>EditLib</Filter>
     </ClInclude>
@@ -1442,6 +1442,12 @@
     </ClInclude>
     <ClInclude Include="CompareEngines\Wrap_DiffUtils.h">
       <Filter>Compare Engines</Filter>
+    </ClInclude>
+    <ClInclude Include="TestMain.h">
+      <Filter>MergeTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>MergeTest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Src/Test.cpp
+++ b/Src/Test.cpp
@@ -57,6 +57,8 @@ TEST(CodepageTest, UTF8)
 	CFrameWnd *pFrame = GetMainFrame()->GetActiveFrame();
 	CMergeDoc *pDoc = dynamic_cast<CMergeDoc *>(pFrame->GetActiveDocument());
 	EXPECT_NE(nullptr, pDoc);
+	if (nullptr == pDoc)
+		return;
 	EXPECT_EQ(ucr::UTF8, pDoc->m_ptBuf[0]->getEncoding().m_unicoding);
 	EXPECT_TRUE(pDoc->m_ptBuf[0]->getEncoding().m_bom);
 	EXPECT_EQ(ucr::UTF8, pDoc->m_ptBuf[1]->getEncoding().m_unicoding);
@@ -77,6 +79,8 @@ TEST(SyntaxHighlight, Verilog)
 	CFrameWnd *pFrame = GetMainFrame()->GetActiveFrame();
 	CMergeDoc *pDoc = dynamic_cast<CMergeDoc *>(pFrame->GetActiveDocument());
 	EXPECT_NE(nullptr, pDoc);
+	if (nullptr == pDoc)
+		return;
 
 	std::vector<CCrystalTextView::TEXTBLOCK> blocks;
 	blocks = pDoc->GetView(0, 0)->GetTextBlocks(0);
@@ -119,6 +123,11 @@ TEST(FolderCompare, IgnoreEOL)
 		CFrameWnd *pFrame = GetMainFrame()->GetActiveFrame();
 		CDirDoc *pDoc = dynamic_cast<CDirDoc *>(pFrame->GetActiveDocument());
 		EXPECT_NE(nullptr, pDoc);
+		if (nullptr == pDoc)
+		{
+			pFrame->PostMessage(WM_CLOSE);
+			continue;
+		}
 		CDirView *pView = pDoc->GetMainView();
 		const CDiffContext& ctxt = pDoc->GetDiffContext();
 		const CompareStats *pStats = ctxt.m_pCompareStats;
@@ -240,6 +249,7 @@ TEST(CommandLineTest, Desc4)
 
 TEST(ImageCompareTest, Open)
 {
+	EXPECT_TRUE(CImgMergeFrame::IsLoadable());
 	if (!CImgMergeFrame::IsLoadable())
 		return;
 


### PR DESCRIPTION
### Attempt to fix the issue #100 - Part 2

- Commit [2f8e009](https://bitbucket.org/winmerge/winmerge/commits/2f8e009c3f473ca0f6a639990d6307ed95d7694e) checks for the existence of the `WinIMergeLib.dll` and abandons the **ImageCompareTest.Open** test if the `.dll` cannot be loaded correctly.  This checking  prevents the inappropriate (and seriously misleading) SEH error later in the code; _**however**_ it allows the test to Pass even when the `.dll` is not present.

    This follow-on patch forces the test to Fail cleanly, with a mildly relevant message, when the `.dll` cannot be loaded correctly.

- Also, the handling of `EXPECT_NE(nullptr, pDoc)` in other tests is improved to prevent SEH errors if `pDoc==nullptr` should ever become `true`.

### Add a new Solution Filter for MergeTest source files

- Add **MergeTest** as a filter folder to the Solution Explorer.

- Move the Files `Test.cpp`, `TestMain.cpp`, `TestMain.h` and `...\gtest\gtest.h` to this new filter folder (they  were in the **MFCGui** folder)

- Add new **MergeTest** solution filter to **VS2015**

### Update project to latest "Platform Version"
 
- With **VS2017** version 15.7.**5** the \<WindowsTargetPlatformVersion\> is now 10.0.**17134**.0

### Additions to .gitignore

- I don't know why these "all of a sudden" became necessary.  The files have always existed and have always seemed to be ignored before ??
