### PR TITLE
"Ghost Lines" at the end of file comparisons.

### DIFF
--- a/Externals/crystaledit/editlib/LineInfo.cpp
+++ b/Externals/crystaledit/editlib/LineInfo.cpp
@@ -91,7 +91,7 @@ void LineInfo::Create(LPCTSTR pszLine, size_t nLength)
     nEols = 2;
   else if (nLength && IsEol(pszLine[nLength - 1]))
     nEols = 1;
-  ASSERT (nEols <= m_nLength);
+  ASSERT (static_cast<size_t>(nEols) <= m_nLength);
   m_nLength -= nEols;
   m_nEolChars = nEols;
 }
@@ -144,7 +144,7 @@ void LineInfo::Append(LPCTSTR pszChars, size_t nLength)
       {
        m_nEolChars = 1;
       }
-   ASSERT (m_nEolChars <= m_nLength);
+   ASSERT (static_cast<size_t>(m_nEolChars) <= m_nLength);
    m_nLength -= m_nEolChars;
    ASSERT (m_nLength + m_nEolChars <= m_nMax);
 }

--- a/Externals/crystaledit/editlib/LineInfo.cpp
+++ b/Externals/crystaledit/editlib/LineInfo.cpp
@@ -219,7 +219,19 @@ void LineInfo::Delete(size_t nStartChar, size_t nEndChar)
       memcpy (m_pcLine + nStartChar, m_pcLine + nEndChar,
               sizeof (TCHAR) * (FullLength() - nEndChar));
     }
-  m_nLength -= (nEndChar - nStartChar);
+  size_t nDelete = (nEndChar - nStartChar);
+  if (nDelete <= m_nLength)
+  {
+	  m_nLength -= nDelete;
+  }
+  else
+  {
+	  ASSERT( (m_nLength + m_nEolChars) <= nDelete );
+	  nDelete -= m_nLength;
+	  m_nLength = 0;
+	  m_nEolChars -= static_cast<int>(nDelete);
+  }
+  ASSERT (m_nLength <= INT_MAX);		// assert "positive int"
   if (m_pcLine)
     m_pcLine[FullLength()] = '\0';
 }

--- a/Externals/crystaledit/editlib/LineInfo.cpp
+++ b/Externals/crystaledit/editlib/LineInfo.cpp
@@ -73,6 +73,7 @@ void LineInfo::Create(LPCTSTR pszLine, size_t nLength)
       return;
     }
 
+  ASSERT (nLength <= INT_MAX);		// assert "positive int"
   m_nLength = nLength;
   m_nMax = ALIGN_BUF_SIZE (m_nLength + 1);
   ASSERT (m_nMax < INT_MAX);
@@ -90,6 +91,7 @@ void LineInfo::Create(LPCTSTR pszLine, size_t nLength)
     nEols = 2;
   else if (nLength && IsEol(pszLine[nLength - 1]))
     nEols = 1;
+  ASSERT (nEols <= m_nLength);
   m_nLength -= nEols;
   m_nEolChars = nEols;
 }
@@ -115,6 +117,7 @@ void LineInfo::CreateEmpty()
  */
 void LineInfo::Append(LPCTSTR pszChars, size_t nLength)
 {
+  ASSERT (nLength <= INT_MAX);		// assert "positive int"
   size_t nBufNeeded = m_nLength + nLength + 1;
   if (nBufNeeded > m_nMax)
     {
@@ -141,6 +144,7 @@ void LineInfo::Append(LPCTSTR pszChars, size_t nLength)
       {
        m_nEolChars = 1;
       }
+   ASSERT (m_nEolChars <= m_nLength);
    m_nLength -= m_nEolChars;
    ASSERT (m_nLength + m_nEolChars <= m_nMax);
 }
@@ -227,6 +231,7 @@ void LineInfo::Delete(size_t nStartChar, size_t nEndChar)
 void LineInfo::DeleteEnd(size_t nStartChar)
 {
   m_nLength = nStartChar;
+  ASSERT (m_nLength <= INT_MAX);		// assert "positive int"
   if (m_pcLine)
     m_pcLine[nStartChar] = 0;
   m_nEolChars = 0;

--- a/Externals/crystaledit/editlib/ccrystaleditview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaleditview.cpp
@@ -313,7 +313,7 @@ DeleteCurrentSelection ()
 }
 
 bool CCrystalEditView::
-DeleteCurrentColumnSelection (int nAction, bool bFlushUndoGroup /*=true*/, bool bUpdateCursorPosition /*=true*/)
+DeleteCurrentColumnSelection (int nAction, bool bFlushUndoGroup /*= true*/, bool bUpdateCursorPosition /*= true*/)
 {
   if (IsSelection ())
     {

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
@@ -1012,7 +1012,7 @@ InternalDeleteText (CCrystalTextView * pSource, int nStartLine, int nStartChar,
   ASSERT (nStartLine >= 0 && nStartLine < (int)m_aLines.size ());
   ASSERT (nStartChar >= 0 && nStartChar <= (int)m_aLines[nStartLine].Length());
   ASSERT (nEndLine >= 0 && nEndLine < (int)m_aLines.size ());
-  ASSERT (nEndChar >= 0 && nEndChar <= (int)m_aLines[nEndLine].Length());
+  ASSERT (nEndChar >= 0 && nEndChar <= (int)m_aLines[nEndLine].FullLength());
   ASSERT (nStartLine < nEndLine || nStartLine == nEndLine && nStartChar <= nEndChar);
   // some edit functions (delete...) should do nothing when there is no selection.
   // assert to be sure to catch these 'do nothing' cases.
@@ -1847,7 +1847,7 @@ FlushUndoGroup (CCrystalTextView * pSource)
   ASSERT (m_bUndoGroup);
   if (pSource != NULL)
     {
-      ASSERT (static_cast<size_t>(m_nUndoPosition) == m_aUndoBuf.size());
+      ASSERT (static_cast<size_t>(m_nUndoPosition) <= m_aUndoBuf.size());
       if (m_nUndoPosition > 0)
         {
           pSource->OnEditOperation (m_aUndoBuf[m_nUndoPosition - 1].m_nAction, m_aUndoBuf[m_nUndoPosition - 1].GetText (), m_aUndoBuf[m_nUndoPosition - 1].GetTextLength ());

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
@@ -1587,7 +1587,7 @@ LPCTSTR CCrystalTextBuffer::GetDefaultEol() const
  * @note Line numbers are apparent (screen) line numbers, not real
  * line numbers in the file.
  */
-bool CCrystalTextBuffer::
+bool CCrystalTextBuffer::			/* virtual base */
 InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText,
     size_t cchText, int &nEndLine, int &nEndChar, int nAction,
     bool bHistory /*= true*/)
@@ -1646,7 +1646,7 @@ InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText,
  * @note Line numbers are apparent (screen) line numbers, not real
  * line numbers in the file.
  */
-bool CCrystalTextBuffer::
+bool CCrystalTextBuffer::			/* virtual base */
 DeleteText (CCrystalTextView * pSource, int nStartLine, int nStartChar,
             int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/, bool bExcludeInvisibleLines /*= true*/)
 {
@@ -1720,7 +1720,7 @@ RestoreRevisionNumbers(int nStartLine, CDWordArray *paSavedRevisionNumbers)
 
 bool CCrystalTextBuffer::			/* virtual base */
 DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartChar,
-            int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/)
+            int nEndLine, int nEndChar, int nAction /* = CE_ACTION_UNKNOWN*/, bool bHistory /*= true*/)
 {
   CString sTextToDelete;
   GetTextWithoutEmptys (nStartLine, nStartChar, nEndLine, nEndChar, sTextToDelete);

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
@@ -790,7 +790,7 @@ GetLineWithFlag (DWORD dwFlag) const
 }
 
 void CCrystalTextBuffer::
-SetLineFlag (int nLine, DWORD dwFlag, bool bSet, bool bRemoveFromPreviousLine /*= true*/ , bool bUpdate /*=true*/)
+SetLineFlag (int nLine, DWORD dwFlag, bool bSet, bool bRemoveFromPreviousLine /*= true*/ , bool bUpdate /*= true*/)
 {
   ASSERT (m_bInit);             //  Text buffer not yet initialized.
   //  You must call InitNew() or LoadFromFile() first!
@@ -854,10 +854,11 @@ SetLineFlag (int nLine, DWORD dwFlag, bool bSet, bool bRemoveFromPreviousLine /*
 /**
  * @brief Get text of specified line range (excluding ghost lines)
  */
-void CCrystalTextBuffer::GetTextWithoutEmptys(int nStartLine, int nStartChar, 
+void CCrystalTextBuffer::			/* virtual base */
+GetTextWithoutEmptys(int nStartLine, int nStartChar, 
                  int nEndLine, int nEndChar, 
-                 CString &text, CRLFSTYLE nCrlfStyle /* CRLF_STYLE_AUTOMATIC */,
-                 bool bExcludeInvisibleLines/*=true*/) const
+                 CString &text, CRLFSTYLE nCrlfStyle /*= CRLF_STYLE_AUTOMATIC */,
+                 bool bExcludeInvisibleLines/*= true*/) const
 {
   GetText(nStartLine, nStartChar, nEndLine, nEndChar, text, (nCrlfStyle == CRLF_STYLE_AUTOMATIC) ? NULL : GetStringEol (nCrlfStyle), bExcludeInvisibleLines);
 }
@@ -865,7 +866,7 @@ void CCrystalTextBuffer::GetTextWithoutEmptys(int nStartLine, int nStartChar,
 
 void CCrystalTextBuffer::
 GetText (int nStartLine, int nStartChar, int nEndLine, int nEndChar,
-		CString & text, LPCTSTR pszCRLF /*= NULL*/, bool bExcludeInvisibleLines/*=true*/) const
+		CString & text, LPCTSTR pszCRLF /*= NULL*/, bool bExcludeInvisibleLines/*= true*/) const
 {
   ASSERT (m_bInit);             //  Text buffer not yet initialized.
   //  You must call InitNew() or LoadFromFile() first!
@@ -1098,8 +1099,6 @@ StripTail (int i, size_t bytes)
  * @param [out] nEndLine Line number of last added line in the buffer.
  * @param [out] nEndChar Character position of the end of the added text
  *   in the buffer.
- * @param [in] nAction Edit action.
- * @param [in] bHistory Save insertion for undo/redo?
  * @return true if the insertion succeeded, false otherwise.
  * @note Line numbers are apparent (screen) line numbers, not real
  * line numbers in the file.
@@ -1499,7 +1498,8 @@ Redo (CCrystalTextView * pSource, CPoint & ptCursorPos)
 }
 
 // the CPoint parameters are apparent (on screen) line numbers
-void CCrystalTextBuffer::
+
+void CCrystalTextBuffer::			/* virtual base */
 AddUndoRecord (bool bInsert, const CPoint & ptStartPos,
     const CPoint & ptEndPos, LPCTSTR pszText, size_t cchText, int nActionType,
     CDWordArray *paSavedRevisionNumbers)
@@ -1590,7 +1590,7 @@ LPCTSTR CCrystalTextBuffer::GetDefaultEol() const
 bool CCrystalTextBuffer::
 InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText,
     size_t cchText, int &nEndLine, int &nEndChar, int nAction,
-    bool bHistory /*=true*/)
+    bool bHistory /*= true*/)
 {
   // save line revision numbers for undo
   CDWordArray *paSavedRevisionNumbers = new CDWordArray;
@@ -1640,14 +1640,15 @@ InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText,
  * @param [in] nEndLine Ending line for the deletion.
  * @param [in] nEndChar Ending char position for the deletion.
  * @param [in] nAction Edit action.
- * @param [in] bHistory Save insertion for undo/redo?
- * @return true if the insertion succeeded, false otherwise.
+ * @param [in] bHistory Save deletion for undo/redo?
+ * @param [in] bExcludeInvisibleLines Don't delete LF_INVISIBLE lines 
+ * @return true if the deletion succeeded, false otherwise.
  * @note Line numbers are apparent (screen) line numbers, not real
  * line numbers in the file.
  */
 bool CCrystalTextBuffer::
 DeleteText (CCrystalTextView * pSource, int nStartLine, int nStartChar,
-            int nEndLine, int nEndChar, int nAction, bool bHistory /*=true*/, bool bExcludeInvisibleLines /*=true*/)
+            int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/, bool bExcludeInvisibleLines /*= true*/)
 {
   bool bGroupFlag = false;
   if (bHistory)
@@ -1717,9 +1718,9 @@ RestoreRevisionNumbers(int nStartLine, CDWordArray *paSavedRevisionNumbers)
 	m_aLines[nStartLine + i].m_dwRevisionNumber = (*paSavedRevisionNumbers)[i];
 }
 
-bool CCrystalTextBuffer::
+bool CCrystalTextBuffer::			/* virtual base */
 DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartChar,
-            int nEndLine, int nEndChar, int nAction, bool bHistory /*=true*/)
+            int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/)
 {
   CString sTextToDelete;
   GetTextWithoutEmptys (nStartLine, nStartChar, nEndLine, nEndChar, sTextToDelete);
@@ -1826,7 +1827,7 @@ GetActionDescription (int nAction, CString & desc) const
   return bSuccess;
 }
 
-void CCrystalTextBuffer::
+void CCrystalTextBuffer::			/* virtual base */
 SetModified (bool bModified /*= true*/ )
 {
   m_bModified = bModified;

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.h
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.h
@@ -257,6 +257,7 @@ public :
     bool CanUndo () const;
     bool CanRedo () const;
     virtual bool Undo (CCrystalTextView * pSource, CPoint & ptCursorPos);
+    virtual bool UndoInsert (CCrystalTextView * pSource, CPoint & ptCursorPos, const CPoint apparent_ptStartPos, CPoint const apparent_ptEndPos, const UndoRecord & ur);
     virtual bool Redo (CCrystalTextView * pSource, CPoint & ptCursorPos);
 
     //  Undo grouping

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.h
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.h
@@ -249,9 +249,9 @@ public :
     void SetIgnoreEol(bool IgnoreEol) { m_IgnoreEol = IgnoreEol; }
 
     //  Text modification functions
-    virtual bool InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText, size_t cchText, int &nEndLine, int &nEndChar, int nAction = CE_ACTION_UNKNOWN, bool bHistory =true);
-    virtual bool DeleteText (CCrystalTextView * pSource, int nStartLine, int nStartPos, int nEndLine, int nEndPos, int nAction = CE_ACTION_UNKNOWN, bool bHistory =true, bool bExcludeInvisibleLines = true);
-    virtual bool DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartPos, int nEndLine, int nEndPos, int nAction = CE_ACTION_UNKNOWN, bool bHistory =true);
+    virtual bool InsertText (CCrystalTextView * pSource, int nLine, int nPos, LPCTSTR pszText, size_t cchText, int &nEndLine, int &nEndChar, int nAction = CE_ACTION_UNKNOWN, bool bHistory = true);
+    virtual bool DeleteText (CCrystalTextView * pSource, int nStartLine, int nStartPos, int nEndLine, int nEndPos, int nAction = CE_ACTION_UNKNOWN, bool bHistory = true, bool bExcludeInvisibleLines = true);
+    virtual bool DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartPos, int nEndLine, int nEndPos, int nAction = CE_ACTION_UNKNOWN, bool bHistory = true);
 
     //  Undo/Redo
     bool CanUndo () const;

--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -4315,7 +4315,7 @@ OnSysColorChange ()
 }
 
 void CCrystalTextView::
-GetText (const CPoint & ptStart, const CPoint & ptEnd, CString & text, bool bExcludeInvisibleLines/*=true*/)
+GetText (const CPoint & ptStart, const CPoint & ptEnd, CString & text, bool bExcludeInvisibleLines /*= true*/)
 {
   if (m_pTextBuffer != NULL)
     m_pTextBuffer->GetText (ptStart.y, ptStart.x, ptEnd.y, ptEnd.x, text);
@@ -4324,7 +4324,7 @@ GetText (const CPoint & ptStart, const CPoint & ptEnd, CString & text, bool bExc
 }
 
 void CCrystalTextView::
-GetTextInColumnSelection (CString & text, bool bExcludeInvisibleLines/*=true*/)
+GetTextInColumnSelection (CString & text, bool bExcludeInvisibleLines /*= true*/)
 {
   if (m_pTextBuffer == NULL)
     {

--- a/Src/DiffTextBuffer.cpp
+++ b/Src/DiffTextBuffer.cpp
@@ -163,7 +163,8 @@ bool CDiffTextBuffer::GetLine(int nLineIndex, CString &strLine) const
  * @param [in] bModified New modified status, true if buffer has been
  *   modified since last saving.
  */
-void CDiffTextBuffer::SetModified(bool bModified /*= true*/)
+void CDiffTextBuffer::			/* virtual override */
+SetModified(bool bModified /*= true*/)	
 {
 	CCrystalTextBuffer::SetModified (bModified);
 	m_pOwnerDoc->SetModifiedFlag (bModified);
@@ -190,7 +191,8 @@ bool CDiffTextBuffer::GetFullLine(int nLineIndex, CString &strLine) const
 	return true;
 }
 
-void CDiffTextBuffer::AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
+void CDiffTextBuffer::			/* virtual override */
+AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
 		const CPoint & ptEndPos, LPCTSTR pszText, size_t cchText,
 		int nActionType /*= CE_ACTION_UNKNOWN*/,
 		CDWordArray *paSavedRevisionNumbers)
@@ -204,6 +206,7 @@ void CDiffTextBuffer::AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
 		m_pOwnerDoc->curUndo = m_pOwnerDoc->undoTgt.end();
 	}
 }
+
 /**
  * @brief Checks if a flag is set for line.
  * @param [in] line Index (0-based) for line.
@@ -236,12 +239,13 @@ void CDiffTextBuffer::prepareForRescan()
 /** 
  * @brief Called when line has been edited.
  * After editing a line, we don't know if there is a diff or not.
- * So we clear the LF_DIFF flag (and it is more easy to read during edition).
+ * So we clear the LF_DIFF flag (and it is more easy to read during editing).
  * Rescan will set the proper color.
  * @param [in] nLine Line that has been edited.
  */
 
-void CDiffTextBuffer::OnNotifyLineHasBeenEdited(int nLine)
+void CDiffTextBuffer::			/* virtual override */
+OnNotifyLineHasBeenEdited(int nLine)
 {
 	SetLineFlag(nLine, LF_DIFF, false, false, false);
 	SetLineFlag(nLine, LF_TRIVIAL, false, false, false);
@@ -700,9 +704,9 @@ bool CDiffTextBuffer::curUndoGroup()
 	return (m_aUndoBuf.size() != 0 && m_aUndoBuf[0].m_dwFlags&UNDO_BEGINGROUP);
 }
 
-bool CDiffTextBuffer::
+bool CDiffTextBuffer::			/* virtual override */
 DeleteText2(CCrystalTextView * pSource, int nStartLine, int nStartChar,
-	int nEndLine, int nEndChar, int nAction, bool bHistory /*=true*/)
+	int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/)
 {
 	for (auto syncpnt : m_pOwnerDoc->GetSyncPointList())
 	{

--- a/Src/DiffTextBuffer.cpp
+++ b/Src/DiffTextBuffer.cpp
@@ -706,7 +706,7 @@ bool CDiffTextBuffer::curUndoGroup()
 
 bool CDiffTextBuffer::			/* virtual override */
 DeleteText2(CCrystalTextView * pSource, int nStartLine, int nStartChar,
-	int nEndLine, int nEndChar, int nAction, bool bHistory /*= true*/)
+	int nEndLine, int nEndChar, int nAction /*= CE_ACTION_UNKNOWN*/, bool bHistory /*= true*/)
 {
 	for (auto syncpnt : m_pOwnerDoc->GetSyncPointList())
 	{

--- a/Src/DiffTextBuffer.h
+++ b/Src/DiffTextBuffer.h
@@ -78,5 +78,5 @@ public :
 	bool IsInitialized() const;
 	virtual bool DeleteText2 (CCrystalTextView * pSource, int nStartLine,
 		int nStartPos, int nEndLine, int nEndPos,
-		int nAction = CE_ACTION_UNKNOWN, bool bHistory =true) override;
+		int nAction = CE_ACTION_UNKNOWN, bool bHistory = true) override;
 };

--- a/Src/GhostTextBuffer.cpp
+++ b/Src/GhostTextBuffer.cpp
@@ -715,7 +715,10 @@ void CGhostTextBuffer::RecomputeRealityMapping()
 passingGhosts:
 	ASSERT( i <= nLineCount );
 	if (i == nLineCount)
+	{
+		checkFlagsFromReality();
 		return;
+	}
 	if (GetLineFlags(i) & LF_GHOST)
 	{
 		++i;
@@ -751,7 +754,10 @@ inReality:
 		}
 		m_RealityBlocks.push_back(block);
 		if (i == nLineCount)
+		{
+			checkFlagsFromReality();
 			return;
+		}
 		++i;
 		goto passingGhosts;
 	}
@@ -764,8 +770,9 @@ inReality:
 Check all lines, and ASSERT if reality blocks differ from flags. 
 This means that this only has effect in DEBUG build
 */
-void CGhostTextBuffer::checkFlagsFromReality(bool bFlag) const
+void CGhostTextBuffer::checkFlagsFromReality() const
 {
+#ifdef _DEBUG
 	const int size = static_cast<int>(m_RealityBlocks.size());
 	int i = 0;
 	for (int b = 0 ; b < size ; b ++)
@@ -779,6 +786,7 @@ void CGhostTextBuffer::checkFlagsFromReality(bool bFlag) const
 
 	for ( ; i < GetLineCount() ; i++)
 		ASSERT ((GetLineFlags(i) & LF_GHOST) != 0);
+#endif 
 }
 
 void CGhostTextBuffer::			/* virtual base */

--- a/Src/GhostTextBuffer.cpp
+++ b/Src/GhostTextBuffer.cpp
@@ -52,6 +52,7 @@ CGhostTextBuffer::CGhostTextBuffer()
 {
 }
 
+#if 0
 /**
  * @brief Insert a ghost line.
  * @param [in] pSource View into which to insert the line.
@@ -78,6 +79,7 @@ bool CGhostTextBuffer::InternalInsertGhostLine (CCrystalTextView * pSource,
 
 	return true;
 }
+#endif
 
 /** InternalDeleteGhostLine accepts only apparent line numbers */
 /**
@@ -145,10 +147,11 @@ bool CGhostTextBuffer::InternalDeleteGhostLine (CCrystalTextView * pSource,
  * These two base functions never read the EOL from the line buffer, they
  * use CRLF_STYLE_DOS when nCrlfStyle equals CRLF_STYLE_AUTOMATIC.
  */
-void CGhostTextBuffer::GetTextWithoutEmptys(int nStartLine, int nStartChar, 
+void CGhostTextBuffer::			/* virtual override */
+GetTextWithoutEmptys(int nStartLine, int nStartChar, 
                  int nEndLine, int nEndChar, 
-                 CString &text, CRLFSTYLE nCrlfStyle /* CRLF_STYLE_AUTOMATIC */,
-                 bool bExcludeInvisibleLines/*=true*/) const
+                 CString &text, CRLFSTYLE nCrlfStyle /*= CRLF_STYLE_AUTOMATIC */,
+                 bool bExcludeInvisibleLines /*= true*/) const
 {
 	const size_t lines = m_aLines.size();
 	ASSERT(nStartLine >= 0 && nStartLine < static_cast<intptr_t>(lines));
@@ -235,6 +238,7 @@ void CGhostTextBuffer::GetTextWithoutEmptys(int nStartLine, int nStartChar,
  * @param [in] nLine Line number (apparent/screen) where the insertion starts.
  * @param [in] nPos Character position where the insertion starts.
  * @param [in] pszText The text to insert.
+ * @param [in] cchText The length of text in pszText.
  * @param [out] nEndLine Line number of last added line in the buffer.
  * @param [out] nEndChar Character position of the end of the added text
  *   in the buffer.
@@ -248,9 +252,10 @@ void CGhostTextBuffer::GetTextWithoutEmptys(int nStartLine, int nStartChar,
  *   variable which is preserved with real line number during Rescan
  *   (m_ptCursorPos, m_ptLastChange for example).
  */
-bool CGhostTextBuffer::InsertText (CCrystalTextView * pSource, int nLine,
+bool CGhostTextBuffer::			/* virtual override */
+InsertText (CCrystalTextView * pSource, int nLine,
 		int nPos, LPCTSTR pszText, size_t cchText, int &nEndLine, int &nEndChar,
-		int nAction, bool bHistory /*=true*/)
+		int nAction /*= CE_ACTION_UNKNOWN*/, bool bHistory /*= true*/)
 {
 	bool bGroupFlag = false;
 	bool bFirstLineGhost = ((GetLineFlags(nLine) & LF_GHOST) != 0);
@@ -351,7 +356,7 @@ bool CGhostTextBuffer::InsertText (CCrystalTextView * pSource, int nLine,
 	return true;
 }
 
-CDWordArray *CGhostTextBuffer::
+CDWordArray *CGhostTextBuffer::			/* virtual override */
 CopyRevisionNumbers(int nStartLine, int nEndLine) const
 {
 	CDWordArray *paSavedRevisionNumbers = CCrystalTextBuffer::CopyRevisionNumbers(nStartLine, nEndLine);
@@ -372,7 +377,7 @@ CopyRevisionNumbers(int nStartLine, int nEndLine) const
 	return paSavedRevisionNumbers;
 }
 
-void CGhostTextBuffer::
+void CGhostTextBuffer::			/* virtual override */
 RestoreRevisionNumbers(int nStartLine, CDWordArray *paSavedRevisionNumbers)
 {
 	for (int i = 0, j = 0; i < paSavedRevisionNumbers->GetSize(); j++)
@@ -385,9 +390,9 @@ RestoreRevisionNumbers(int nStartLine, CDWordArray *paSavedRevisionNumbers)
 	}
 }
 
-bool CGhostTextBuffer::
+bool CGhostTextBuffer::			/* virtual override */
 DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartChar,
-            int nEndLine, int nEndChar, int nAction, bool bHistory /*=true*/)
+            int nEndLine, int nEndChar, int nAction /*= CE_ACTION_UNKNOWN*/, bool bHistory /*= true*/)
 {
 	if ((GetLineFlags(nEndLine) & LF_GHOST) == 0)
 	{
@@ -441,6 +446,7 @@ DeleteText2 (CCrystalTextView * pSource, int nStartLine, int nStartChar,
 	return true;
 }
 
+#if 0
 /**
  * @brief Insert a ghost line to the buffer (and view).
  * @param [in] pSource The view to which to add the ghost line.
@@ -460,6 +466,7 @@ bool CGhostTextBuffer::InsertGhostLine (CCrystalTextView * pSource, int nLine)
 	// Never AddUndoRecord as Rescan clears the ghost lines.
 	return true;
 }
+#endif
 
 /**
  * @brief Remove all the ghost lines from the buffer.
@@ -566,8 +573,8 @@ int CGhostTextBuffer::ComputeApparentLine(int nRealLine) const
  * @brief Get a real line for apparent (screen) line.
  * This function returns the real line for the given apparent (screen) line.
  * For ghost lines we return next real line. For trailing ghost line we return
- * last real line + 1). Ie, lines 0->0, 1->2, 2->4, for argument of 3,
- * return 2. And decToReal would be 1.
+ * last real line + 1; i.e. lines 0->0, 1->2, 2->4, for argument of 3,
+ * return 2 and decToReal would be 1.
  * @param [in] nApparentLine Apparent line for which to get the real line.
  * @param [out] decToReal Difference of the apparent and real line.
  * @return The real line for the apparent line.
@@ -618,7 +625,7 @@ int CGhostTextBuffer::ComputeRealLineAndGhostAdjustment(int nApparentLine,
 /**
  * @brief Get an apparent (screen) line for the real line.
  * @param [in] nRealLine Real line for which to get the apparent line.
- * @param [out] decToReal Difference of the apparent and real line.
+ * @param [in] decToReal Difference of the apparent and real line.
  * @return The apparent line for the real line. If real line is out of bounds
  *   return last valid apparent line + 1.
  */
@@ -774,7 +781,8 @@ void CGhostTextBuffer::checkFlagsFromReality(bool bFlag) const
 		ASSERT ((GetLineFlags(i) & LF_GHOST) != 0);
 }
 
-void CGhostTextBuffer::OnNotifyLineHasBeenEdited(int nLine)
+void CGhostTextBuffer::			/* virtual base */
+OnNotifyLineHasBeenEdited(int nLine)
 {
 	return;
 }
@@ -794,7 +802,9 @@ static int CountEol(LPCTSTR pszText, size_t cchText)
 	return nEol;
 }
 
-void CGhostTextBuffer::AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
+
+void CGhostTextBuffer::			/* virtual override */
+AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
 	const CPoint & ptEndPos, LPCTSTR pszText, size_t cchText,
 	int nActionType /*= CE_ACTION_UNKNOWN*/,
 	CDWordArray *paSavedRevisionNumbers)
@@ -805,7 +815,8 @@ void CGhostTextBuffer::AddUndoRecord(bool bInsert, const CPoint & ptStartPos,
 		cchText, nActionType, paSavedRevisionNumbers);
 }
 
-UndoRecord CGhostTextBuffer::GetUndoRecord(int nUndoPos) const
+UndoRecord CGhostTextBuffer::			/* virtual override */
+GetUndoRecord(int nUndoPos) const
 {
 	UndoRecord ur = m_aUndoBuf[nUndoPos];
 	ur.m_ptStartPos.y = ComputeApparentLine(ur.m_ptStartPos.y, 0);

--- a/Src/GhostTextBuffer.cpp
+++ b/Src/GhostTextBuffer.cpp
@@ -95,7 +95,8 @@ bool CGhostTextBuffer::InternalDeleteGhostLine (CCrystalTextView * pSource,
 {
 	ASSERT (m_bInit);             //  Text buffer not yet initialized.
 	//  You must call InitNew() or LoadFromFile() first!
-	ASSERT (nLine >= 0 && nLine <= static_cast<intptr_t>(m_aLines.size ()));
+	ASSERT (nCount >= 0);
+	ASSERT (nLine >= 0 && (nLine + nCount) <= static_cast<intptr_t>(m_aLines.size ()));
 
 	if (nCount == 0)
 		return true;

--- a/Src/GhostTextBuffer.cpp
+++ b/Src/GhostTextBuffer.cpp
@@ -897,7 +897,7 @@ UndoInsert(CCrystalTextView * pSource, CPoint & ptCursorPos, const CPoint appare
 					if (m_aLines[nLastLine].Length() == 0)
 					{
 						m_aLines[nLastLine].Clear();
-						if (ptCursorPos.y == nLastLine)
+						if (static_cast<size_t>(ptCursorPos.y) == nLastLine)
 							ptCursorPos.y--;
 					}
 					return true;

--- a/Src/GhostTextBuffer.h
+++ b/Src/GhostTextBuffer.h
@@ -92,6 +92,8 @@ public :
 	virtual void AddUndoRecord (bool bInsert, const CPoint & ptStartPos, const CPoint & ptEndPos,
 	                            LPCTSTR pszText, size_t cchText, int nActionType = CE_ACTION_UNKNOWN, CDWordArray *paSavedRevisionNumbers = NULL) override;
 	virtual UndoRecord GetUndoRecord(int nUndoPos) const override;
+	virtual bool UndoInsert(CCrystalTextView * pSource, CPoint & ptCursorPos,
+							const CPoint apparent_ptStartPos, CPoint const apparent_ptEndPos, const UndoRecord & ur) override;
 
 	virtual CDWordArray *CopyRevisionNumbers(int nStartLine, int nEndLine) const override;
 	virtual void RestoreRevisionNumbers(int nStartLine, CDWordArray *paSavedRevisionNumbers) override;

--- a/Src/GhostTextBuffer.h
+++ b/Src/GhostTextBuffer.h
@@ -59,7 +59,9 @@ private:
 
 	// Operations
 private:
+#if 0
 	bool InternalInsertGhostLine (CCrystalTextView * pSource, int nLine);
+#endif
 	bool InternalDeleteGhostLine (CCrystalTextView * pSource, int nLine, int nCount);
 public :
 	// Construction/destruction code
@@ -83,7 +85,9 @@ public :
 	virtual bool DeleteText2 (CCrystalTextView * pSource, int nStartLine,
 		int nStartPos, int nEndLine, int nEndPos,
 		int nAction = CE_ACTION_UNKNOWN, bool bHistory =true) override;
+#if 0
 	bool InsertGhostLine (CCrystalTextView * pSource, int nLine);
+#endif
 
 	virtual void AddUndoRecord (bool bInsert, const CPoint & ptStartPos, const CPoint & ptEndPos,
 	                            LPCTSTR pszText, size_t cchText, int nActionType = CE_ACTION_UNKNOWN, CDWordArray *paSavedRevisionNumbers = NULL) override;

--- a/Src/GhostTextBuffer.h
+++ b/Src/GhostTextBuffer.h
@@ -124,7 +124,7 @@ public:
 private:
 	void RecomputeRealityMapping();
 	/** For debugging purpose */
-	void checkFlagsFromReality(bool bFlag) const;
+	void checkFlagsFromReality() const;
 
 protected:
 	virtual void OnNotifyLineHasBeenEdited(int nLine);

--- a/Src/GhostTextView.cpp
+++ b/Src/GhostTextView.cpp
@@ -200,8 +200,8 @@ int CGhostTextView::ComputeApparentLine (int nRealLine) const
 
 void CGhostTextView::GetTextWithoutEmptys (int nStartLine, int nStartChar,
 		int nEndLine, int nEndChar, CString &text,
-		CRLFSTYLE nCrlfStyle /*=CRLF_STYLE_AUTOMATIC*/,
-		bool bExcludeInvisibleLines/*=false*/)
+		CRLFSTYLE nCrlfStyle /*= CRLF_STYLE_AUTOMATIC*/,
+		bool bExcludeInvisibleLines /*= true*/)
 {
   if (m_pGhostTextBuffer != NULL)
     m_pGhostTextBuffer->GetTextWithoutEmptys (nStartLine, nStartChar, nEndLine, nEndChar, text, nCrlfStyle, bExcludeInvisibleLines);
@@ -209,7 +209,7 @@ void CGhostTextView::GetTextWithoutEmptys (int nStartLine, int nStartChar,
     text = _T ("");
 }
 
-void CGhostTextView::GetTextWithoutEmptysInColumnSelection (CString & text, bool bExcludeInvisibleLines/*=true*/)
+void CGhostTextView::GetTextWithoutEmptysInColumnSelection (CString & text, bool bExcludeInvisibleLines /*= true*/)
 {
 	if (m_pGhostTextBuffer == NULL)
 	{

--- a/Src/GhostTextView.h
+++ b/Src/GhostTextView.h
@@ -102,11 +102,11 @@ public:
 	/** real cursor function to preserve cursor during Rescan */
 	void PushCursors ();
 
-	virtual void GetTextWithoutEmptys (int nStartLine, int nStartChar,
+	void GetTextWithoutEmptys (int nStartLine, int nStartChar,
 			int nEndLine, int nEndChar, CString &text,
-			CRLFSTYLE nCrlfStyle =CRLF_STYLE_AUTOMATIC,
+			CRLFSTYLE nCrlfStyle = CRLF_STYLE_AUTOMATIC,
 			bool bExcludeInvisibleLines = true);
-	virtual void GetTextWithoutEmptysInColumnSelection (CString & text,
+	void GetTextWithoutEmptysInColumnSelection (CString & text,
 			bool bExcludeInvisibleLines = true);
 	/** 
 	 * @brief Override this drag-n-drop function to call GetTextWithoutEmptys

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -806,7 +806,7 @@ void CMergeEditView::OnDisplayDiff(int nDiff /*=0*/)
  * @sa CMergeDoc::SetCurrentDiff()
  * @todo Parameter bSelectText is never used?
  */
-void CMergeEditView::SelectDiff(int nDiff, bool bScroll /*=true*/, bool bSelectText /*=true*/)
+void CMergeEditView::SelectDiff(int nDiff, bool bScroll /*= true*/, bool bSelectText /*= true*/)
 {
 	CMergeDoc *pd = GetDocument();
 


### PR DESCRIPTION
# "Ghost Lines" at the end of file comparisons.

Pull Requests [#90](https://github.com/sdottaka/winmerge-v2/pull/90) and [#89](https://github.com/sdottaka/winmerge-v2/pull/89) have solved various problems with the handling of the last lines of a comparison.  PR [#90](https://github.com/sdottaka/winmerge-v2/pull/90) indicated that there were still additional problems to be solved.  I claim that this group of commits ***solves the remainder of those problems***.  As usual, there are also changes to comments, ASSERTs, formatting, etc.

## Improve comments relating to "ghost buffers"

* Correct and extend various parameter comments, especially for **Doxygen** 

* Make sure default parameter values in a function _definition_ are properly commented in the function _declaration_ as well

* Add either `/*virtual base*/` or `/*virtual override*/` comments to various "ghost buffer " related procedure declarations.

* Eliminate (using `#if 0` and `#endif`) the procedures `InternalInsertGhostLine()` and `InsertGhostLine()` which are never used.

## Enable `checkFlagsFromReality()` Debug checking

* The `checkFlagsFromReality()` procedure was never called.  It is now called from two places in `CGhostTextBuffer::RecomputeRealityMapping()`.

* The complete internals of the procedure are now guarded by `_DEBUG`

* The parameter `bool bFlag` is never used and is now eliminated.

## Improve Various ASSERTs related to "Ghost Buffers"

## Improve comments relating to "ghost buffers" (2)

* continuing from earlier commit.


## Last Line of files vs "Ghost Lines" (1 .. 4)

### Last Line of files vs "Ghost Lines" (1)

The special case of inserting text into the very last line of a file when that last line is marked as `LF_GHOST`.  Effectively, the new text is supposed to go "before" the Ghost, but mechanically the text is inserted into the Ghost itself, with a new Ghost line appearing at the end of the file.

Later, the Ghost status of both the first and last inserted lines will get straightened out, with the trailing Ghost line becoming a NULL line.  By setting the last line to NULL, the line will eventually be removed or become an actual LF_GHOST line in `CMergeDoc::PrimeTextBuffers()`

### Last Line of Files vs "Ghost Lines" (2)

Handle the special case of `Undo()` at the very end of a file.

`Undo()` checks that the text that is being replaced in the file matches the records being kept in the `m_aUndoBuf[]` structure.  The deletion of text at very end of the file necessary involves removing an additional CRLF (because of an `LF_GHOST` line which was removed too) which causes this Undo comparison-checking to fail.

Following failure, and only if the failure is at the very end of the file, a new secondary check is made to check for the deletion of the additional CRLF.

**NOTE:** I don't particularly like this code because it puts knowledge of "Ghost" lines directly into the code of the `CCrystalTextBuffer` class.  A subsequent patch will factor this into virtual procedures shared with the `CGhostTextBuffer` class.  Spoiler ... (see my following "*... Ghost Lines (4)*" commit)

### Last Line of Files vs "Ghost Lines" (3)

`LineInfo::Delete()` was not correctly handling the case of deleting all text in a line _including_ the CRLF at the end.  This particular situation exists because of deleting text at the very end of a file.

### Last Line of Files vs "Ghost Lines" (4)

Re-implements the Undo handling for the last line (see my final comments in the earlier "*... Ghost Lines (2)*" commit) 

* Move the "Ghost" sensitive parts out of the `CCrystalTextBuffer` class and into the `GhostTextBuffer` class.

* A new virtual procedure `UndoInsert()`now exists in both `CCrystalTextBuffer` and `GhostTextBuffer`, with the WinMerge and Ghost specific checking in the `GhostTextBuffer`class, and the basic deletion code (for undoing an Insert) in the `CCrystalTextBuffer`class.

* Also, modify the `VERIFY()`testing in the Undo paths to correctly interface with the general failure mechanism within `Undo()`

## Reduce Level 4 Build Warnings (12)

* I must have missed these three Level 4 Warning situations in the earlier Pull Request #90
* They were only generated when building the **Test** configuration for the **Win32** platform.

