### PR TITLE
Adapt to latest VS2017 version 15.8, and more ...

### DIFF
--- a/Externals/boost/boost/config/compiler/visualc.hpp
+++ b/Externals/boost/boost/config/compiler/visualc.hpp
@@ -320,7 +320,8 @@
 // VS2017 Version 15.5.0 (cl compiler version 19.12.25830.2) updated _MSC_VER to 1912 - BillGord 06 Dec 2017
 // VS2017 Version 15.6.1 (cl compiler version 19.13.26128) updated _MSC_VER to 1913 - BillGord 06 Mar 2018
 // VS2017 Version 15.7.1 (cl compiler version 19.14.26428.1) updated _MSC_VER to 1914 - BillGord 20 May 2018
-#if (_MSC_VER > 1914)
+// VS2017 Version 15.8.0 (cl compiler version 19.15.26726) updated _MSC_VER to 1915 - BillGord 15 Aug 2018
+#if (_MSC_VER > 1915)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/Externals/gtest/include/gtest/gtest-printers.h
+++ b/Externals/gtest/include/gtest/gtest-printers.h
@@ -480,6 +480,14 @@ inline void PrintTo(const ::std::wstring& s, ::std::ostream* os) {
 }
 #endif  // GTEST_HAS_STD_WSTRING
 
+//! see "Address #1616, add printer for std::nullptr_t" PR#1620 (merged)
+//!		https://github.com/google/googletest/pull/1620
+//! and "Workaround nonportable operator<< assumptions in VS2017 15.8" PR#1617
+//! and "Google Test fails to compile if a standard library implements LWG 2221" PR#1616
+#if GTEST_LANG_CXX11
+inline void PrintTo(std::nullptr_t, ::std::ostream* os) { *os << "(nullptr)"; }
+#endif  // GTEST_LANG_CXX11
+
 #if GTEST_HAS_TR1_TUPLE
 // Overload for ::std::tr1::tuple.  Needed for printing function arguments,
 // which are packed as tuples.

--- a/Externals/poco/Foundation/src/File_WIN32U.cpp
+++ b/Externals/poco/Foundation/src/File_WIN32U.cpp
@@ -433,8 +433,12 @@ void FileImpl::convertPath(const std::string& utf8Path, std::wstring& utf16Path)
 			if (utf16Path.compare(0, 4, L"\\\\?\\", 4) != 0)
 			{
 				if (utf16Path[1] == '\\')
-					utf16Path.insert(0, L"\\\\?\\UNC\\", 8);
+					//	Starting with  "\\\\server\\etc\\etc..."
+					//	Form resulting "\\\\?\\UNC\\server\\etc\\etc..."
+					utf16Path.insert(1, L"\\?\\UNC", 6);
 				else
+					//	Starting with  "C:\\etc\\etc..."
+					//	Form resulting "\\\\?\\C:\\etc\\etc..."
 					utf16Path.insert(0, L"\\\\?\\", 4);
 			}
 		}

--- a/Src/ConfigLog.cpp
+++ b/Src/ConfigLog.cpp
@@ -68,15 +68,8 @@ static String GetCompilerVersion()
 	sVisualStudio = _T("VS.2017 (15.0) - "); 
 #elif	_MSC_VER == 1911
 	sVisualStudio = _T("VS.2017 (15.3) - "); 
-#elif	_MSC_VER == 1912
-	sVisualStudio = _T("VS.2017 (15.5) - "); 
-#elif	_MSC_VER == 1913
-	sVisualStudio = _T("VS.2017 (15.6) - ");
-#elif	_MSC_VER == 1914
-	sVisualStudio = _T("VS.2017 (15.7) - ");
-#elif	_MSC_VER <  2000
-	sVisualStudio = _T("VS.2017 (15.7++) - "); 
-	# pragma message ("** ConfigLog.cpp (GetCompilerVersion): Update new Visual Studio version **")
+#elif	_MSC_VER >= 1912 && _MSC_VER <  2000
+	sVisualStudio = strutils::format(_T("VS.2017 (15.%d) - "), 5 + (_MSC_VER - 1912));
 #elif	_MSC_VER >= 2000
 	# error "** Unknown NEW Version of Visual Studio **"
 #endif

--- a/Src/Merge.vs2015.vcxproj
+++ b/Src/Merge.vs2015.vcxproj
@@ -523,6 +523,14 @@
     <ClCompile Include="..\Externals\crystaledit\editlib\vhdl.cpp" />
     <ClCompile Include="..\Externals\crystaledit\editlib\ViewableWhitespace.cpp" />
     <ClCompile Include="..\Externals\crystaledit\editlib\xml.cpp" />
+    <ClCompile Include="..\Externals\gtest\src\gtest-all.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="7zCommon.cpp">
     </ClCompile>
     <ClCompile Include="AboutDlg.cpp">
@@ -941,7 +949,30 @@
     <ClInclude Include="..\Externals\crystaledit\editlib\UndoRecord.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ViewableWhitespace.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\wispelld.h" />
-    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h" />
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest-printers.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\Version.h" />
     <ClInclude Include="7zCommon.h" />
     <ClInclude Include="AboutDlg.h" />

--- a/Src/Merge.vs2015.vcxproj.filters
+++ b/Src/Merge.vs2015.vcxproj.filters
@@ -59,6 +59,9 @@
     <Filter Include="MergeTest">
       <UniqueIdentifier>{63f0497b-0d8f-4660-b727-dac620d74635}</UniqueIdentifier>
     </Filter>
+    <Filter Include="MergeTest\gtest">
+      <UniqueIdentifier>{67c954df-e54f-4070-9c75-68ef52a00e03}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -781,6 +784,9 @@
     <ClCompile Include="TestMain.cpp">
       <Filter>MergeTest</Filter>
     </ClCompile>
+    <ClCompile Include="..\Externals\gtest\src\gtest-all.cc">
+      <Filter>MergeTest\gtest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="charsets.h">
@@ -1440,11 +1446,17 @@
     <ClInclude Include="TestMain.h">
       <Filter>MergeTest</Filter>
     </ClInclude>
-    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
-      <Filter>MergeTest</Filter>
-    </ClInclude>
     <ClInclude Include="Win_VersionHelper.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>MergeTest\gtest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest-printers.h">
+      <Filter>MergeTest\gtest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <Filter>MergeTest\gtest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -529,6 +529,14 @@
     <ClCompile Include="..\Externals\crystaledit\editlib\vhdl.cpp" />
     <ClCompile Include="..\Externals\crystaledit\editlib\ViewableWhitespace.cpp" />
     <ClCompile Include="..\Externals\crystaledit\editlib\xml.cpp" />
+    <ClCompile Include="..\Externals\gtest\src\gtest-all.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="7zCommon.cpp">
     </ClCompile>
     <ClCompile Include="AboutDlg.cpp">
@@ -947,7 +955,30 @@
     <ClInclude Include="..\Externals\crystaledit\editlib\UndoRecord.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\ViewableWhitespace.h" />
     <ClInclude Include="..\Externals\crystaledit\editlib\wispelld.h" />
-    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h" />
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest-printers.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Test|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeRelease|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='UnicodeDebug|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\Version.h" />
     <ClInclude Include="7zCommon.h" />
     <ClInclude Include="AboutDlg.h" />

--- a/Src/Merge.vs2017.vcxproj
+++ b/Src/Merge.vs2017.vcxproj
@@ -132,7 +132,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>.;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -194,7 +194,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>.;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -252,7 +252,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>.;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_DEBUG;WIN32;_WINDOWS;__NT__;POCO_STATIC;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PR_FILE_NAME="pr";EDITPADC_CLASS=;UNICODE;_AFX_NO_MFC_CONTROLS_IN_DIALOGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -306,7 +306,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>.;..\Externals\gtest;..\Externals\gtest\include;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>TEST_WINMERGE;WINVER=0x0501;_DEBUG;WIN32;_WINDOWS;__NT__;POCO_STATIC;PR_FILE_NAME="pr";EDITPADC_CLASS=;UNICODE;_AFX_NO_MFC_CONTROLS_IN_DIALOGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;GTEST_HAS_TR1_TUPLE=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -364,7 +364,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>.;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_DEBUG;WIN64;_WINDOWS;__NT__;POCO_STATIC;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;PR_FILE_NAME="pr";EDITPADC_CLASS=;UNICODE;_AFX_NO_MFC_CONTROLS_IN_DIALOGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -423,7 +423,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/EHa  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>.;..\Externals\gtest;..\Externals\gtest\include;.\CompareEngines;.\Common;..\Externals\crystaledit\editlib;.\diffutils;.\diffutils\lib;.\diffutils\src;..\Externals\boost;..\Externals\poco\Foundation\include;..\Externals\poco\XML\include;..\Externals\poco\Util\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>TEST_WINMERGE;WINVER=0x0501;_DEBUG;WIN64;_WINDOWS;__NT__;POCO_STATIC;PR_FILE_NAME="pr";EDITPADC_CLASS=;UNICODE;_AFX_NO_MFC_CONTROLS_IN_DIALOGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;GTEST_HAS_TR1_TUPLE=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Src/Merge.vs2017.vcxproj.filters
+++ b/Src/Merge.vs2017.vcxproj.filters
@@ -59,6 +59,9 @@
     <Filter Include="MergeTest">
       <UniqueIdentifier>{63f0497b-0d8f-4660-b727-dac620d74635}</UniqueIdentifier>
     </Filter>
+    <Filter Include="MergeTest\gtest">
+      <UniqueIdentifier>{67c954df-e54f-4070-9c75-68ef52a00e03}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="charsets.c">
@@ -781,6 +784,9 @@
     <ClCompile Include="TestMain.cpp">
       <Filter>MergeTest</Filter>
     </ClCompile>
+    <ClCompile Include="..\Externals\gtest\src\gtest-all.cc">
+      <Filter>MergeTest\gtest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="charsets.h">
@@ -1440,11 +1446,17 @@
     <ClInclude Include="TestMain.h">
       <Filter>MergeTest</Filter>
     </ClInclude>
-    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
-      <Filter>MergeTest</Filter>
-    </ClInclude>
     <ClInclude Include="Win_VersionHelper.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest.h">
+      <Filter>MergeTest\gtest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\gtest-printers.h">
+      <Filter>MergeTest\gtest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Externals\gtest\include\gtest\internal\gtest-port.h">
+      <Filter>MergeTest\gtest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# Adapt to latest VS2017 version 15.8, and more ...

### Correct Extended Length Path Name handling on UNC

* Too many `\\` characters were being inserted when forming Extended Length Path Names on UNC  (i.e. Network Storage) devices.  This is a bug in the original **Poco** library code.

* Cleanup awkward code in `SuperComboBox.cpp` for detecting and handling UNC file path names.

### Adapt to latest VS2017 version 15.8

* As is often the case, the boost library needs to update its warning message for the new compiler version.

* There is a bug in the **gtest** software; it is using a non-portable `operator<<` overload.  The ambiguity of this usage is now being flagged as an error by **VS2017** version **15.8**.  There have been many updates to the **gtest** software since the version incorporated into WinMerge, but fortunately the "accepted" and merged solution to this problem simply drops into **WinMerge** without issue (although I've added some comments referencing the **gtest** PR#1620 - https://github.com/google/googletest/pull/1620)

* Unfortunately, in order to trigger the source code in **gtest** PR#1620, the value of the standard predefined macro **`__cplusplus`** must be accurate.  For various reasons (see https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/) the compiler option `Zc:__cplusplus` must be set in order for the compiler to generate correct (i.e. standard) values for `__cplusplus` during a build.  The changes to the `*.vs2017.vcxproj` file accomplish this.  Note that the elimination of the "additional option" `/EHa` is acceptable because that option is properly specified elsewhere in the project's build properties.

* This commit can be used to close [Bitbucket issue #101](https://bitbucket.org/winmerge/winmerge/issues/101/upgrading-to-vs2017-version-158-causes)

### Add new node to Solution Explorer for a few gtest files

* With the testing for the recent **gtest** bug it became convenient to have a new filter node in the Solution Explorer for making the code visible to Intellisense.  Additional files beyond simply `gtest-printers.h` were necessary to prevent **Intellisense** from presuming various false configuration errors.  This new node is **`gtest`** within the existing `MergeTest` node.

* The Solution Explorer additions are copied into **VS2015**, simply for consistency.

### Adapt to latest VS2017 version 15.8 (2)

* Update the presentation of the "Visual Studio Version" in the WinMerge Configuration Log file.

